### PR TITLE
[STORY] Phase 5 - Remove HTML coverage reporting from local and CI workflows

### DIFF
--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci-checks:
-    name: "🔍 Tests & Coverage"
+    name: "Tests & Coverage"
     runs-on: ubuntu-latest
 
     steps:
@@ -40,10 +40,3 @@ jobs:
           PYTEST_ADDOPTS: -m "not integration"
         run: |
           uv run --locked --group test pytest
-
-      - name: Upload HTML coverage report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: htmlcov
-          path: htmlcov

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -44,10 +44,3 @@ jobs:
           PYTEST_ADDOPTS: -m "not integration"
         run: |
           uv run --locked --group test pytest
-
-      - name: Upload HTML coverage report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: htmlcov
-          path: htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ exclude = ["tests*", "logs*"]
 [tool.pytest.ini_options]
 addopts = [
     "--cov",
-    "--cov-report=html",
     "--cov-report=term",
 ]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Removes HTML coverage report generation and CI artifact upload while keeping terminal coverage feedback in pytest.

## Changes

- Remove `--cov-report=html` from pytest configuration.
- Keep `--cov-report=term` for terminal coverage feedback.
- Remove the `htmlcov` artifact upload step from the main CI workflow.
- Remove the `htmlcov` artifact upload step from the feature branch CI workflow.
- Keep existing test paths, markers, integration exclusion strategy, and coverage source configuration unchanged.

## Deliberately out of scope

- No Python code changes.
- No dependency version changes.
- No Docker or Docker Compose changes.
- No test scope changes.

## Validation to run before merge

```bash
uv sync --locked --group dev
uv run --locked --group test ruff check .
uv run --locked --group test pytest -m "not integration"
docker compose --profile all config
```

Local cleanup instructions still remove stale `htmlcov` directories when present.

Closes #36