### PR TITLE
[STORY] Phase 5 - Stabilize Makefile targets around uv and Docker Compose

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,10 @@
 # Used by: make repo_setup
 GIT_USER="[replace_me]"
 GIT_EMAIL="[replace_me]"
-DAGSHUB_KEY="[replace_me]"
+# Used by: make dvc-setup to populate .dvc/config.local.
+# These values authenticate the DVC S3 remote hosted by DagsHub.
+DAGSHUB_ACCESS_KEY_ID="[replace_me]"
+DAGSHUB_SECRET_ACCESS_KEY="[replace_me]"
 
 # =================== Makefile defaults ========================================
 # Used by: make start/stop/logs/sim_api_req

--- a/.env.template
+++ b/.env.template
@@ -59,11 +59,19 @@ GRID_ITER=0
 DATA_FINAL_ROOT="/app/data/final"
 
 # =================== MLflow and MinIO =========================================
+# Docker Compose default values. These addresses are resolved from containers.
 MLFLOW_TRACKING_URI="http://mlflow-server:5000"
 MLFLOW_S3_ENDPOINT_URL="http://mlflow-minio:9000"
 AWS_ACCESS_KEY_ID="minio"
 AWS_SECRET_ACCESS_KEY="[replace_me]"
 AWS_DEFAULT_REGION="us-east-1"
+
+# Optional DagsHub remote MLflow values.
+# When using DagsHub instead of the local MLflow service, override
+# MLFLOW_TRACKING_URI in your local `.env` with:
+# https://dagshub.com/zheddhe/avr25-mle-trafic-cycliste.mlflow
+MLFLOW_TRACKING_USERNAME="[replace_me]"
+MLFLOW_TRACKING_PASSWORD="[replace_me]"
 
 # =================== Airflow ==================================================
 # AIRFLOW_UID usually matches: id -u

--- a/.env.template
+++ b/.env.template
@@ -87,7 +87,10 @@ GRAFANA_ADMIN_PASSWORD="[replace_me]"
 
 # =================== Monitoring ==============================================
 PUSHGATEWAY_ADDR="monitoring-pushgateway:9091"
-DISABLE_METRICS_PUSH=0
+# Keep metric push disabled by default for safe local commands and tests.
+# Set to 0 only when the Pushgateway service is available and should receive
+# metrics from ML/API pipeline code.
+DISABLE_METRICS_PUSH=1
 
 # =================== Miscellaneous ===========================================
 # Time zone used for local conversions.

--- a/.env.template
+++ b/.env.template
@@ -1,56 +1,86 @@
-# =================== Ingestion (src/ml/ingest/import_raw_data.py) ===================
-# Nom du CSV brut déjà présent sous ./data/raw (monté en volume)
+# ==============================================================================
+# Local developer settings
+# ==============================================================================
+# Copy this file to `.env` before running Docker Compose or Makefile targets that
+# rely on local environment variables.
+#
+# Use `[replace_me]` placeholders for sensitive or user-specific values. Do not
+# commit a populated `.env` file.
+
+# =================== Git and DVC local setup ==================================
+# Used by: make repo_setup
+GIT_USER="[replace_me]"
+GIT_EMAIL="[replace_me]"
+DAGSHUB_KEY="[replace_me]"
+
+# =================== Makefile defaults ========================================
+# Used by: make start/stop/logs/sim_api_req
+PROFILE="ptf"
+SERVICE="api-dev"
+URL="http://localhost:10000"
+N=100
+P_OK=0.80
+API_USER="user1"
+API_PASS="user1"
+LIMIT=10
+OFFSET=0
+COUNTER_IDS="Sebastopol_N-S_airflow_day0,Sebastopol_S-N_airflow_day0"
+
+# =================== Ingestion (src/ml/ingest/import_raw_data.py) =============
+# Raw CSV file already present under ./data/raw and mounted as a volume.
 RAW_FILE_NAME="comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv"
 
-# Filtrage du compteur (voir colonnes du CSV)
+# Counter filtering values based on the source CSV columns.
 SITE="Totem 73 boulevard de Sébastopol"
 ORIENTATION="N-S"
 
-# Plage de pourcentages à garder (0–100)
+# Percentage range to keep, from 0 to 100.
 RANGE_START=0.0
 RANGE_END=75.0
 
-# Dossier logique pour chaîner toute la run
+# Logical subdirectory used to chain the whole run.
 SUB_DIR="Sebastopol_N-S_mlops"
 INTERIM_NAME="initial.csv"
 
-# =================== Features (src/ml/features/build_features.py) =================
-# Nom du CSV de sortie après features
+# =================== Features (src/ml/features/build_features.py) =============
+# Output CSV name after feature engineering.
 PROCESSED_NAME="initial_with_feats.csv"
 
-# =================== Modélisation (src/ml/models/train_and_predict.py) ===========
-# Hyperparamètres principaux + split temporel
+# =================== Modeling (src/ml/models/train_and_predict.py) ============
+# Main hyperparameters and temporal split.
 AR=7
 MM=1
 ROLL=24
 TEST_RATIO=0.25
 GRID_ITER=0
 
-# =================== API (src/api/main.py) =================
-# Nom du répertoire contenant les prédictions finales 
+# =================== API (src/api/main.py) ====================================
+# Directory containing final prediction files inside the API container.
 DATA_FINAL_ROOT="/app/data/final"
 
-# =================== MLflow & MinIO (override optionnel) ========================
+# =================== MLflow and MinIO =========================================
 MLFLOW_TRACKING_URI="http://mlflow-server:5000"
 MLFLOW_S3_ENDPOINT_URL="http://mlflow-minio:9000"
 AWS_ACCESS_KEY_ID="minio"
-AWS_SECRET_ACCESS_KEY="minio123"
+AWS_SECRET_ACCESS_KEY="[replace_me]"
 AWS_DEFAULT_REGION="us-east-1"
 
-# =================== Airflow (override optionnel) ========================
-AIRFLOW_UID=1000 # airflow uses current user (id -u)
-AIRFLOW_GID=1001 # airflow uses docker group (getent group docker | cut -d: -f3)
-AIRFLOW_WWW_USER_USERNAME=airflow
-AIRFLOW_WWW_USER_PASSWORD=airflow
+# =================== Airflow ==================================================
+# AIRFLOW_UID usually matches: id -u
+# AIRFLOW_GID usually matches: getent group docker | cut -d: -f3
+AIRFLOW_UID=1000
+AIRFLOW_GID=1001
+AIRFLOW_WWW_USER_USERNAME="airflow"
+AIRFLOW_WWW_USER_PASSWORD="[replace_me]"
 
-# =================== Grafana (override optionnel) ========================
-GRAFANA_ADMIN_USER=grafana
-GRAFANA_ADMIN_PASSWORD=grafana
+# =================== Grafana ==================================================
+GRAFANA_ADMIN_USER="grafana"
+GRAFANA_ADMIN_PASSWORD="[replace_me]"
 
-# =================== Monitoring ===================
+# =================== Monitoring ==============================================
 PUSHGATEWAY_ADDR="monitoring-pushgateway:9091"
 DISABLE_METRICS_PUSH=0
 
-# =================== Divers ======================================================
-# Fuseau horaire utile aux conversions locales
+# =================== Miscellaneous ===========================================
+# Time zone used for local conversions.
 TZ="Europe/Paris"

--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,15 @@ help: ## Display this help
 	' $(MAKEFILE_LIST)
 
 bootstrap: ## Install Python bootstrap dependencies
-	@echo "==> Install python3, pip, pipx, and git"
+	@$(call log_test,bootstrap)
 	sudo apt update
 	sudo apt install --fix-missing
 	sudo apt install -y python3 python3-pip pipx git
 	pipx ensurepath
-	@echo "==> Install uv"
 	pipx install uv
 
 docker-install: ## Install Docker Engine and Compose plugin on Ubuntu
-	@echo "==> Install Docker host dependencies"
+	@$(call log_test,docker-install)
 	sudo apt update
 	sudo apt install -y ca-certificates curl gnupg lsb-release
 	sudo install -m 0755 -d /etc/apt/keyrings
@@ -90,6 +89,7 @@ env: ## Create a local .env file from .env.template if missing
 setup: env sync compose-config ## Prepare the local project after cloning
 
 git-setup: env ## Configure local Git identity from .env
+	@$(call log_test,git-setup)
 	@$(load_env)
 	@if [ -z "$${GIT_USER:-}" ] || [ "$${GIT_USER}" = "[replace_me]" ]; then \
 		echo "Error: GIT_USER is not set in $(ENV_FILE)."; \
@@ -99,11 +99,11 @@ git-setup: env ## Configure local Git identity from .env
 		echo "Error: GIT_EMAIL is not set in $(ENV_FILE)."; \
 		exit 1; \
 	fi
-	@echo "==> Set up Git user name and email"
 	git config --global user.name "$${GIT_USER}"
 	git config --global user.email "$${GIT_EMAIL}"
 
 dvc-setup: env sync ## Configure local DVC credentials in .dvc/config.local
+	@$(call log_test,dvc-setup)
 	@$(load_env)
 	@if [ ! -d ".dvc" ]; then \
 		echo "Error: .dvc directory is missing. Run 'dvc init' before configuring remotes."; \
@@ -117,7 +117,6 @@ dvc-setup: env sync ## Configure local DVC credentials in .dvc/config.local
 		echo "Error: DAGSHUB_SECRET_ACCESS_KEY is not set in $(ENV_FILE)."; \
 		exit 1; \
 	fi
-	@echo "==> Set up local DVC remote credentials in .dvc/config.local"
 	$(UV) run --locked --group dev dvc remote modify origin --local \
 		access_key_id "$${DAGSHUB_ACCESS_KEY_ID}"
 	$(UV) run --locked --group dev dvc remote modify origin --local \
@@ -149,9 +148,11 @@ compose-config: env ## Validate the Docker Compose configuration
 	$(DOCKER_COMPOSE) --profile all config >/dev/null
 
 build: env ## Build Docker images for all profiles
+	@$(call log_test,build)
 	$(DOCKER_COMPOSE) --profile all build
 
 rebuild_full: env ## Rebuild Docker images and restart platform services
+	@$(call log_test,rebuild_full)
 	$(DOCKER_COMPOSE) --profile all build
 	$(DOCKER_COMPOSE) --profile all down
 	$(DOCKER_COMPOSE) --profile ptf up -d
@@ -159,28 +160,33 @@ rebuild_full: env ## Rebuild Docker images and restart platform services
 ops: env compose-config start ## Validate and start platform services
 
 start: env ## Start Docker services for the selected profile
-	@echo "==> Starting Docker services with profile [$(PROFILE)]"
+	@$(call log_test,start PROFILE=$(PROFILE))
 	$(DOCKER_COMPOSE) --profile $(PROFILE) up -d
 
 stop: ## Stop Docker services for the selected profile
-	@echo "==> Stopping Docker services with profile [$(PROFILE)]"
+	@$(call log_test,stop PROFILE=$(PROFILE))
 	$(DOCKER_COMPOSE) --profile $(PROFILE) stop
 
 logs: ## Show Docker Compose logs for SERVICE
+	@$(call log_test,logs SERVICE=$(SERVICE))
 	$(DOCKER_COMPOSE) logs -f -t $(SERVICE)
 
 ml-ingest: env ## Run the ML ingestion container once
+	@$(call log_test,ml-ingest)
 	$(DOCKER_COMPOSE) --profile ml up ml-ingest-dev
 
 ml-features: env ## Run the ML feature engineering container once
+	@$(call log_test,ml-features)
 	$(DOCKER_COMPOSE) --profile ml up ml-features-dev
 
 ml-models: env ## Run the ML training and prediction container once
+	@$(call log_test,ml-models)
 	$(DOCKER_COMPOSE) --profile ml up ml-models-dev
 
 ml-pipeline: ml-ingest ml-features ml-models ## Run the full one-off ML pipeline
 
 mlflow-host: sync ## Start a host-side MLflow server for local experiments
+	@$(call log_test,mlflow-host)
 	$(UV) run --locked --group app mlflow server \
 		--host $(MLFLOW_HOST) \
 		--port $(MLFLOW_HOST_PORT) \
@@ -188,7 +194,7 @@ mlflow-host: sync ## Start a host-side MLflow server for local experiments
 		--default-artifact-root $(MLFLOW_ARTIFACT_ROOT)
 
 sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
-	@echo "==> Simulating API restart failure loop"
+	@$(call log_test,sim_api_loop)
 	for i in {1..10}; do \
 		echo "[restart $$i] stopping api-dev..."; \
 		$(DOCKER_COMPOSE) stop api-dev; \
@@ -201,13 +207,13 @@ sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
 	@echo "==> Simulation finished"
 
 sim_api_down: ## Simulate a temporary API outage for 2 minutes
-	@echo "==> Simulating API down for 2 minutes"
+	@$(call log_test,sim_api_down)
 	$(DOCKER_COMPOSE) stop api-dev
 	sleep 120
 	$(DOCKER_COMPOSE) up -d api-dev
 
 sim_api_req: ## Simulate traffic on /predictions/{counter}
-	@echo "==> Simulating /predictions/* traffic on $(URL)"
+	@$(call log_test,sim_api_req)
 	$(UV) run --locked --group test python tests/integration/test_load_api.py \
 		--url "$(URL)" \
 		--n $(N) \
@@ -219,15 +225,18 @@ sim_api_req: ## Simulate traffic on /predictions/{counter}
 		$(if $(COUNTER_IDS),--counter-ids "$(COUNTER_IDS)",)
 
 clean: ## Remove local Python caches and test artifacts only
+	@$(call log_test,clean)
 	rm -rf .nox .pytest_cache .ruff_cache .coverage htmlcov build dist mlruns mlflow.db
 	find . -type d -name "__pycache__" -prune -exec rm -rf {} +
 	find . -type d -name "*.egg-info" -prune -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
 clean_env: ## Remove the uv-managed virtual environment
+	@$(call log_test,clean_env)
 	rm -rf .venv
 
 clean_full: ## Remove Docker artifacts, including images, volumes, and networks
+	@$(call log_test,clean_full)
 	$(DOCKER_COMPOSE) --profile all down -v --rmi all
 	docker system prune -f
 	docker volume prune -f

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,15 @@ SHELL := /bin/bash
 # Default make target.
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap repo_setup
+.PHONY: help bootstrap env setup repo_setup
 .PHONY: sync lock-check lint test ci compose-config
-.PHONY: build rebuild_full start stop logs
+.PHONY: build rebuild_full ops start stop logs
 .PHONY: sim_api_loop sim_api_down sim_api_req
 .PHONY: clean clean_env clean_full
 
 UV ?= uv
 DOCKER_COMPOSE ?= docker compose
+ENV_FILE ?= .env
 PROFILE ?= ptf
 SERVICE ?= api-dev
 URL ?= http://localhost:10000
@@ -25,6 +26,7 @@ OFFSET ?= 0
 COUNTER_IDS ?= Sebastopol_N-S_airflow_day0,Sebastopol_S-N_airflow_day0
 
 log_test = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
+load_env = if [ -f "$(ENV_FILE)" ]; then set -a; source "$(ENV_FILE)"; set +a; fi
 
 help: ## Display this help
 	@awk ' \
@@ -44,14 +46,34 @@ bootstrap: ## Install bootstrap dependencies
 	@echo "==> Install uv"
 	pipx install uv
 
-repo_setup: ## Configure Git identity and local DVC S3 credentials
-	@echo "==> Set up Git user name and email"
-	git config --global user.name "$${GIT_USER:-change_me}"
-	git config --global user.email "$${GIT_EMAIL:-change_me@mail.com}"
-	@if [ -z "$${DAGSHUB_KEY:-}" ]; then \
-		echo "Error: DAGSHUB_KEY is not set."; \
+env: ## Create a local .env file from .env.template if missing
+	@if [ -f "$(ENV_FILE)" ]; then \
+		echo "==> $(ENV_FILE) already exists. Nothing to do."; \
+	else \
+		cp .env.template "$(ENV_FILE)"; \
+		echo "==> Created $(ENV_FILE) from .env.template"; \
+		echo "==> Replace [replace_me] placeholders before running secret-based targets."; \
+	fi
+
+setup: env sync compose-config ## Prepare the local project after cloning
+
+repo_setup: env ## Configure Git identity and local DVC S3 credentials
+	@$(load_env)
+	@if [ -z "$${GIT_USER:-}" ] || [ "$${GIT_USER}" = "[replace_me]" ]; then \
+		echo "Error: GIT_USER is not set in $(ENV_FILE)."; \
 		exit 1; \
 	fi
+	@if [ -z "$${GIT_EMAIL:-}" ] || [ "$${GIT_EMAIL}" = "[replace_me]" ]; then \
+		echo "Error: GIT_EMAIL is not set in $(ENV_FILE)."; \
+		exit 1; \
+	fi
+	@if [ -z "$${DAGSHUB_KEY:-}" ] || [ "$${DAGSHUB_KEY}" = "[replace_me]" ]; then \
+		echo "Error: DAGSHUB_KEY is not set in $(ENV_FILE)."; \
+		exit 1; \
+	fi
+	@echo "==> Set up Git user name and email"
+	git config --global user.name "$${GIT_USER}"
+	git config --global user.email "$${GIT_EMAIL}"
 	@echo "==> Set up local DVC credentials"
 	$(UV) run --locked --group dev dvc remote modify origin --local \
 		access_key_id "$${DAGSHUB_KEY}"
@@ -77,19 +99,21 @@ test: ## Run unit tests while excluding integration tests
 
 ci: lock-check lint test ## Run local CI checks
 
-compose-config: ## Validate the Docker Compose configuration
+compose-config: env ## Validate the Docker Compose configuration
 	@$(call log_test,compose-config)
 	$(DOCKER_COMPOSE) --profile all config >/dev/null
 
-build: ## Build Docker images for all profiles
+build: env ## Build Docker images for all profiles
 	$(DOCKER_COMPOSE) --profile all build
 
-rebuild_full: ## Rebuild Docker images and restart platform services
+rebuild_full: env ## Rebuild Docker images and restart platform services
 	$(DOCKER_COMPOSE) --profile all build
 	$(DOCKER_COMPOSE) --profile all down
 	$(DOCKER_COMPOSE) --profile ptf up -d
 
-start: ## Start Docker services for the selected profile
+ops: env compose-config start ## Validate and start platform services
+
+start: env ## Start Docker services for the selected profile
 	@echo "==> Starting Docker services with profile [$(PROFILE)]"
 	$(DOCKER_COMPOSE) --profile $(PROFILE) up -d
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,42 @@
 SHELL := /bin/bash
 .ONESHELL:
-# flags de gestion du comportement sur erreur (sortie immediate et sur premiere erreur en pipe)
+# Error handling flags: immediate exit and exit on first pipe error.
 .SHELLFLAGS := -eu -o pipefail -c
-# cible make par defaut : help
+# Default make target.
 .DEFAULT_GOAL := help
 
-bootstrap: ## Initialise les dependances bootstrap nécessaires
-	@echo "==> Install python3/pip/pipx"
+.PHONY: help bootstrap repo_setup
+.PHONY: sync lock-check lint test ci compose-config
+.PHONY: build rebuild_full start stop logs
+.PHONY: sim_api_loop sim_api_down sim_api_req
+.PHONY: clean clean_env clean_full
+
+UV ?= uv
+DOCKER_COMPOSE ?= docker compose
+PROFILE ?= ptf
+SERVICE ?= api-dev
+URL ?= http://localhost:10000
+N ?= 100
+P_OK ?= 0.80
+API_USER ?= user1
+API_PASS ?= user1
+LIMIT ?= 10
+OFFSET ?= 0
+COUNTER_IDS ?= Sebastopol_N-S_airflow_day0,Sebastopol_S-N_airflow_day0
+
+log_test = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
+
+help: ## Display this help
+	@awk ' \
+		BEGIN {FS=":.*##"; printf "\nAvailable targets:\n\n"} \
+		/^[a-zA-Z0-9_.-]+:.*##/ { \
+			printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 \
+		} \
+		/^.DEFAULT_GOAL/ {print ""} \
+	' $(MAKEFILE_LIST)
+
+bootstrap: ## Install bootstrap dependencies
+	@echo "==> Install python3, pip, and pipx"
 	sudo apt update
 	sudo apt install --fix-missing
 	sudo apt install -y python3 python3-pip pipx
@@ -14,60 +44,84 @@ bootstrap: ## Initialise les dependances bootstrap nécessaires
 	@echo "==> Install uv"
 	pipx install uv
 
-repo_setup: ## Configure le repo DVC S3 (dagshub) et les credentials github
-	@echo "==> Set up GIT user name and email using ${GIT_USER:-change_me} and ${GIT_EMAIL:-change_me@mail.com}"
-	git config --global user.name ${GIT_USER:-change_me}
-	git config --global user.email ${GIT_EMAIL:-change_me@mail.com}
-	@echo "==> Set up local DVC secrets using ${DAGSHUB_KEY} and ${DAGSHUB_KEY}"
-	dvc remote modify origin --local access_key_id ${DAGSHUB_KEY}
-	dvc remote modify origin --local secret_access_key ${DAGSHUB_KEY}
+repo_setup: ## Configure Git identity and local DVC S3 credentials
+	@echo "==> Set up Git user name and email"
+	git config --global user.name "$${GIT_USER:-change_me}"
+	git config --global user.email "$${GIT_EMAIL:-change_me@mail.com}"
+	@if [ -z "$${DAGSHUB_KEY:-}" ]; then \
+		echo "Error: DAGSHUB_KEY is not set."; \
+		exit 1; \
+	fi
+	@echo "==> Set up local DVC credentials"
+	$(UV) run --locked --group dev dvc remote modify origin --local \
+		access_key_id "$${DAGSHUB_KEY}"
+	$(UV) run --locked --group dev dvc remote modify origin --local \
+		secret_access_key "$${DAGSHUB_KEY}"
 
-rebuild_full: ## Recrée les images docker et relance les services complètement
-	docker compose --profile all build
-	docker compose --profile all down
-	docker compose --profile ptf up -d
+sync: ## Sync the local uv environment from uv.lock
+	@$(call log_test,sync)
+	$(UV) sync --locked --group test --group dev
 
-PROFILE ?= all
+lock-check: ## Check that uv.lock is consistent with pyproject.toml
+	@$(call log_test,lock-check)
+	$(UV) lock --check
 
-start: ## Démarre les services docker du profil choisi (PROFILE=all/mlflow/airflow/monitoring/api/ptf)
-	@echo "==> Starting docker services with profile [$(PROFILE)]"
-	docker compose --profile $(PROFILE) start
+lint: ## Run Ruff checks
+	@$(call log_test,lint)
+	$(UV) run --locked --group test ruff check .
 
-stop: ## Stoppe les services docker du profil choisi (PROFILE=all/mlflow/airflow/monitoring/api/ptf)
-	@echo "==> Stopping docker services with profile [$(PROFILE)]"
-	docker compose --profile $(PROFILE) stop
+test: ## Run unit tests while excluding integration tests
+	@$(call log_test,test)
+	PYTEST_ADDOPTS='-m "not integration"' \
+		$(UV) run --locked --group test pytest
 
-sim_api_loop: ## Simule un arrêt relance de l'API 10 fois a intervalle de 5s
-	@echo "==> Simulating API restart failure loop (10 restarts, 5s interval)"
+ci: lock-check lint test ## Run local CI checks
+
+compose-config: ## Validate the Docker Compose configuration
+	@$(call log_test,compose-config)
+	$(DOCKER_COMPOSE) --profile all config >/dev/null
+
+build: ## Build Docker images for all profiles
+	$(DOCKER_COMPOSE) --profile all build
+
+rebuild_full: ## Rebuild Docker images and restart platform services
+	$(DOCKER_COMPOSE) --profile all build
+	$(DOCKER_COMPOSE) --profile all down
+	$(DOCKER_COMPOSE) --profile ptf up -d
+
+start: ## Start Docker services for the selected profile
+	@echo "==> Starting Docker services with profile [$(PROFILE)]"
+	$(DOCKER_COMPOSE) --profile $(PROFILE) up -d
+
+stop: ## Stop Docker services for the selected profile
+	@echo "==> Stopping Docker services with profile [$(PROFILE)]"
+	$(DOCKER_COMPOSE) --profile $(PROFILE) stop
+
+logs: ## Show Docker Compose logs for SERVICE
+	$(DOCKER_COMPOSE) logs -f -t $(SERVICE)
+
+sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
+	@echo "==> Simulating API restart failure loop"
 	for i in {1..10}; do \
 		echo "[restart $$i] stopping api-dev..."; \
-		docker compose stop api-dev; \
+		$(DOCKER_COMPOSE) stop api-dev; \
 		sleep 2; \
 		echo "[restart $$i] starting api-dev..."; \
-		docker compose start api-dev; \
+		$(DOCKER_COMPOSE) up -d api-dev; \
 		echo "[restart $$i] done, waiting 5s..."; \
 		sleep 5; \
 	done
 	@echo "==> Simulation finished"
 
-sim_api_down: ## Simule un arrêt temporaire de l'API pendant 2 minutes
-	@echo "==> Simulating API down for 2 min"
-	docker compose stop api-dev
+sim_api_down: ## Simulate a temporary API outage for 2 minutes
+	@echo "==> Simulating API down for 2 minutes"
+	$(DOCKER_COMPOSE) stop api-dev
 	sleep 120
-	docker compose start api-dev
+	$(DOCKER_COMPOSE) up -d api-dev
 
-URL         ?= http://localhost:10000
-N           ?= 100
-P_OK        ?= 0.80
-API_USER    ?= user1
-API_PASS    ?= user1
-LIMIT       ?= 10
-OFFSET      ?= 0
-COUNTER_IDS ?= Sebastopol_N-S_airflow_day0,Sebastopol_S-N_airflow_day0
-
-sim_api_req: ## %200, %4XX et volume (RPS & pred/s) sur /predictions/{counter}
+sim_api_req: ## Simulate traffic on /predictions/{counter}
 	@echo "==> Simulating /predictions/* traffic on $(URL)"
-	python3 tests/integration/test_load_api.py \
+	$(UV) run --locked --group test python tests/integration/test_load_api.py \
 		--url "$(URL)" \
 		--n $(N) \
 		--p-ok $(P_OK) \
@@ -77,8 +131,16 @@ sim_api_req: ## %200, %4XX et volume (RPS & pred/s) sur /predictions/{counter}
 		--offset $(OFFSET) \
 		$(if $(COUNTER_IDS),--counter-ids "$(COUNTER_IDS)",)
 
-clean_full: ## Nettoie les artefacts (images/volumes/networks)
-	docker compose --profile all down -v --rmi all && docker system prune -f && docker volume prune -f
+clean: ## Remove local Python caches and test artifacts only
+	rm -rf .nox .pytest_cache .ruff_cache .coverage htmlcov build dist
+	find . -type d -name "__pycache__" -prune -exec rm -rf {} +
+	find . -type d -name "*.egg-info" -prune -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
 
-help: ## Affiche cette aide
-	@awk 'BEGIN{FS=":.*##"; printf "\nTargets disponibles:\n\n"} /^[a-zA-Z0-9_.-]+:.*##/{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2} /^.DEFAULT_GOAL/{print ""} ' $(MAKEFILE_LIST)
+clean_env: ## Remove the uv-managed virtual environment
+	rm -rf .venv
+
+clean_full: ## Remove Docker artifacts, including images, volumes, and networks
+	$(DOCKER_COMPOSE) --profile all down -v --rmi all
+	docker system prune -f
+	docker volume prune -f

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 # Default make target.
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap docker-install env setup repo_setup
+.PHONY: help bootstrap docker-install env setup git-setup dvc-setup repo_setup
 .PHONY: sync lock-check lint test ci compose-config
 .PHONY: build rebuild_full ops start stop logs
 .PHONY: ml-ingest ml-features ml-models ml-pipeline mlflow-host
@@ -89,7 +89,7 @@ env: ## Create a local .env file from .env.template if missing
 
 setup: env sync compose-config ## Prepare the local project after cloning
 
-repo_setup: env ## Configure Git identity and local DVC S3 credentials
+git-setup: env ## Configure local Git identity from .env
 	@$(load_env)
 	@if [ -z "$${GIT_USER:-}" ] || [ "$${GIT_USER}" = "[replace_me]" ]; then \
 		echo "Error: GIT_USER is not set in $(ENV_FILE)."; \
@@ -99,18 +99,31 @@ repo_setup: env ## Configure Git identity and local DVC S3 credentials
 		echo "Error: GIT_EMAIL is not set in $(ENV_FILE)."; \
 		exit 1; \
 	fi
-	@if [ -z "$${DAGSHUB_KEY:-}" ] || [ "$${DAGSHUB_KEY}" = "[replace_me]" ]; then \
-		echo "Error: DAGSHUB_KEY is not set in $(ENV_FILE)."; \
-		exit 1; \
-	fi
 	@echo "==> Set up Git user name and email"
 	git config --global user.name "$${GIT_USER}"
 	git config --global user.email "$${GIT_EMAIL}"
-	@echo "==> Set up local DVC credentials"
+
+dvc-setup: env sync ## Configure local DVC credentials in .dvc/config.local
+	@$(load_env)
+	@if [ ! -d ".dvc" ]; then \
+		echo "Error: .dvc directory is missing. Run 'dvc init' before configuring remotes."; \
+		exit 1; \
+	fi
+	@if [ -z "$${DAGSHUB_ACCESS_KEY_ID:-}" ] || [ "$${DAGSHUB_ACCESS_KEY_ID}" = "[replace_me]" ]; then \
+		echo "Error: DAGSHUB_ACCESS_KEY_ID is not set in $(ENV_FILE)."; \
+		exit 1; \
+	fi
+	@if [ -z "$${DAGSHUB_SECRET_ACCESS_KEY:-}" ] || [ "$${DAGSHUB_SECRET_ACCESS_KEY}" = "[replace_me]" ]; then \
+		echo "Error: DAGSHUB_SECRET_ACCESS_KEY is not set in $(ENV_FILE)."; \
+		exit 1; \
+	fi
+	@echo "==> Set up local DVC remote credentials in .dvc/config.local"
 	$(UV) run --locked --group dev dvc remote modify origin --local \
-		access_key_id "$${DAGSHUB_KEY}"
+		access_key_id "$${DAGSHUB_ACCESS_KEY_ID}"
 	$(UV) run --locked --group dev dvc remote modify origin --local \
-		secret_access_key "$${DAGSHUB_KEY}"
+		secret_access_key "$${DAGSHUB_SECRET_ACCESS_KEY}"
+
+repo_setup: git-setup dvc-setup ## Configure Git identity and local DVC credentials
 
 sync: ## Sync the local uv environment from uv.lock
 	@$(call log_test,sync)

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ SHELL := /bin/bash
 # Default make target.
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap env setup repo_setup
+.PHONY: help bootstrap docker-install env setup repo_setup
 .PHONY: sync lock-check lint test ci compose-config
 .PHONY: build rebuild_full ops start stop logs
+.PHONY: ml-ingest ml-features ml-models ml-pipeline mlflow-host
 .PHONY: sim_api_loop sim_api_down sim_api_req
 .PHONY: clean clean_env clean_full
 
@@ -25,6 +26,16 @@ LIMIT ?= 10
 OFFSET ?= 0
 COUNTER_IDS ?= Sebastopol_N-S_airflow_day0,Sebastopol_S-N_airflow_day0
 
+DOCKER_KEYRING := /etc/apt/keyrings/docker.gpg
+DOCKER_LIST := /etc/apt/sources.list.d/docker.list
+DOCKER_GPG_URL := https://download.docker.com/linux/ubuntu/gpg
+DOCKER_REPO_URL := https://download.docker.com/linux/ubuntu
+
+MLFLOW_HOST ?= 127.0.0.1
+MLFLOW_HOST_PORT ?= 5000
+MLFLOW_BACKEND_STORE ?= sqlite:///mlflow.db
+MLFLOW_ARTIFACT_ROOT ?= ./mlruns
+
 log_test = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
 load_env = if [ -f "$(ENV_FILE)" ]; then set -a; source "$(ENV_FILE)"; set +a; fi
 
@@ -37,14 +48,35 @@ help: ## Display this help
 		/^.DEFAULT_GOAL/ {print ""} \
 	' $(MAKEFILE_LIST)
 
-bootstrap: ## Install bootstrap dependencies
-	@echo "==> Install python3, pip, and pipx"
+bootstrap: ## Install Python bootstrap dependencies
+	@echo "==> Install python3, pip, pipx, and git"
 	sudo apt update
 	sudo apt install --fix-missing
-	sudo apt install -y python3 python3-pip pipx
+	sudo apt install -y python3 python3-pip pipx git
 	pipx ensurepath
 	@echo "==> Install uv"
 	pipx install uv
+
+docker-install: ## Install Docker Engine and Compose plugin on Ubuntu
+	@echo "==> Install Docker host dependencies"
+	sudo apt update
+	sudo apt install -y ca-certificates curl gnupg lsb-release
+	sudo install -m 0755 -d /etc/apt/keyrings
+	curl -fsSL $(DOCKER_GPG_URL) | \
+		sudo gpg --dearmor --yes -o $(DOCKER_KEYRING)
+	echo \
+		"deb [arch=$$(dpkg --print-architecture) signed-by=$(DOCKER_KEYRING)] \
+		$(DOCKER_REPO_URL) $$(lsb_release -cs) stable" | \
+		sudo tee $(DOCKER_LIST) > /dev/null
+	sudo apt update
+	sudo apt install -y \
+		docker-ce \
+		docker-ce-cli \
+		containerd.io \
+		docker-buildx-plugin \
+		docker-compose-plugin
+	sudo usermod -aG docker "$$USER"
+	@echo "==> Docker installed. Open a new shell or run: newgrp docker"
 
 env: ## Create a local .env file from .env.template if missing
 	@if [ -f "$(ENV_FILE)" ]; then \
@@ -124,6 +156,24 @@ stop: ## Stop Docker services for the selected profile
 logs: ## Show Docker Compose logs for SERVICE
 	$(DOCKER_COMPOSE) logs -f -t $(SERVICE)
 
+ml-ingest: env ## Run the ML ingestion container once
+	$(DOCKER_COMPOSE) --profile ml up ml-ingest-dev
+
+ml-features: env ## Run the ML feature engineering container once
+	$(DOCKER_COMPOSE) --profile ml up ml-features-dev
+
+ml-models: env ## Run the ML training and prediction container once
+	$(DOCKER_COMPOSE) --profile ml up ml-models-dev
+
+ml-pipeline: ml-ingest ml-features ml-models ## Run the full one-off ML pipeline
+
+mlflow-host: sync ## Start a host-side MLflow server for local experiments
+	$(UV) run --locked --group app mlflow server \
+		--host $(MLFLOW_HOST) \
+		--port $(MLFLOW_HOST_PORT) \
+		--backend-store-uri $(MLFLOW_BACKEND_STORE) \
+		--default-artifact-root $(MLFLOW_ARTIFACT_ROOT)
+
 sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
 	@echo "==> Simulating API restart failure loop"
 	for i in {1..10}; do \
@@ -156,7 +206,7 @@ sim_api_req: ## Simulate traffic on /predictions/{counter}
 		$(if $(COUNTER_IDS),--counter-ids "$(COUNTER_IDS)",)
 
 clean: ## Remove local Python caches and test artifacts only
-	rm -rf .nox .pytest_cache .ruff_cache .coverage htmlcov build dist
+	rm -rf .nox .pytest_cache .ruff_cache .coverage htmlcov build dist mlruns mlflow.db
 	find . -type d -name "__pycache__" -prune -exec rm -rf {} +
 	find . -type d -name "*.egg-info" -prune -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This project implements a complete machine learning and MLOps architecture in th
 avr25-mle-trafic-cycliste/
 ├── LICENSE             <- MIT license
 ├── README.md           <- This top-level README for developers using this project
+├── Makefile            <- Local developer and Docker Compose operation targets
+├── .env.template       <- Template for local secrets and runtime variables
 ├── pyproject.toml      <- Python project, dependency groups, pytest, coverage, and Ruff configuration
 ├── uv.lock             <- uv lockfile for the local development environment
 ├── data                <- Data shared with host (read/write)
@@ -81,41 +83,15 @@ avr25-mle-trafic-cycliste/
 ├── docker/             <- Container architecture
 │   ├── dev/            <- Development setup
 │   │   ├── grafana/    <- Config for Grafana dashboards and provisioning
-│   │   │   ├── dashboards/
-│   │   │   │   └── cadvisor_docker_insights.json
-│   │   │   └── provisioning/
-│   │   │       ├── dashboards.yaml
-│   │   │       └── datasource.yaml
 │   │   ├── prometheus/ <- Config for Prometheus targets and general configuration
-│   │   │   └── prometheus.yml
 │   │   ├── airflow/    <- Config and DAGs for Airflow
-│   │   │   ├── dags/
-│   │   │   │   ├── bike_traffic_orchestrator_dag.py
-│   │   │   │   ├── bike_traffic_pipeline_dag.py
-│   │   │   │   └── common
-│   │   │   │       └── utils.py
-│   │   │   ├── bike_dag_config.json
-│   │   │   ├── connections.json
-│   │   │   └── variables.json
 │   │   ├── mlflow/     <- Custom Docker image for MLflow service
-│   │   │   └── Dockerfile
 │   │   ├── api/        <- Custom Docker image for API service
-│   │   │   ├── requirements.txt
-│   │   │   └── Dockerfile
 │   │   └── ml/         <- Custom Docker images for ML pipeline services
-│   │       ├── ingest/
-│   │       │   ├── requirements.txt
-│   │       │   └── Dockerfile
-│   │       ├── features/
-│   │       │   ├── requirements.txt
-│   │       │   └── Dockerfile
-│   │       └── models/
-│   │           ├── requirements.txt
-│   │           └── Dockerfile
 │   └── prod/           <- Production setup
 │       └── ...
 └── tests/
-    ├── unitary/        <- Unit tests (pytest for source code coverage)
+    ├── unitary/        <- Unit tests
     │   └── ...
     └── integration/    <- Integration tests
         └── ...
@@ -123,80 +99,69 @@ avr25-mle-trafic-cycliste/
 
 ## ⚙️ Installation
 
-### 🔧 Prerequisites
+The installation flow is split in two parts:
 
-Initialize the development environment with Python, pipx, and uv, preferably from a
-Linux virtual machine on your operating system.
+1. **Pre-clone bootstrap**, before this repository is available locally.
+2. **Post-clone setup**, once the Makefile is available and should be preferred.
+
+### 1. Pre-clone bootstrap
+
+These commands are intentionally shown explicitly because the repository and its
+Makefile are not available yet.
 
 #### Optional virtual machine creation on Windows
 
 ```powershell
-# Check and activate the local virtual machine hypervisor.
 Set-Service -Name WSLService -StartupType Automatic
 Start-Service -Name WSLService
 Get-Service WSLService
-
-# Install an Ubuntu distribution.
 wsl --install -d Ubuntu
 ```
 
-#### Linux, through a virtual machine or directly
+#### Linux bootstrap dependencies
 
 All commands in this README are provided from a Linux operating system point of view.
 
 ```bash
-# Check and update your VM libraries, Python, pip, and pipx.
 sudo apt update
 sudo apt install --fix-missing
-sudo apt install -y python3 python3-pip pipx
+sudo apt install -y python3 python3-pip pipx git
 pipx ensurepath
-
-# Install uv as the local project environment and dependency manager.
 pipx install uv
 ```
 
-### 🔧 Repository cloning and local environment setup
+#### GitHub SSH access and repository cloning
 
 ```bash
-# Set up your local Git identity and clone the repository.
-git config --global user.name "your user"
-git config --global user.email "your_email@example.com"
-
-# Configure your VM public key on GitHub by using an ed25519 key.
 ssh-keygen -t ed25519 -C "your_email@example.com"
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_ed25519
-
-# Copy the content of your public key to GitHub > Settings > SSH and GPG keys.
 cat ~/.ssh/id_ed25519.pub
-
-# Check your connection.
 ssh -T git@github.com
 
-# Clone the repository.
 git clone git@github.com:zheddhe/avr25-mle-trafic-cycliste.git
 cd avr25-mle-trafic-cycliste
 ```
 
-Create your local `.env` file from the tracked template before running Makefile
-or Docker Compose commands:
+### 2. Post-clone project setup
+
+From this point, prefer Makefile targets over raw commands.
 
 ```bash
-cp .env.template .env
+make help
+make env
+make setup
 ```
 
-Then replace every `[replace_me]` value in `.env` with your local values. The
-`.env` file is intentionally not tracked by Git because it may contain secrets.
-Docker Compose reads `.env` automatically from the repository root. For shell
-commands such as `make repo_setup`, load it explicitly when needed:
+`make env` creates `.env` from `.env.template` if it does not already exist.
+Replace every `[replace_me]` placeholder in `.env` before running targets that
+need secrets or user-specific values.
 
-```bash
-set -a
-source .env
-set +a
-```
+The `.env` file is intentionally not tracked by Git because it may contain
+secrets. Docker Compose reads `.env` automatically from the repository root.
+Makefile targets that need repository secrets can load it internally.
 
-DVC setup can then be performed through the Makefile:
+Once `.env` is populated, configure Git identity and DVC credentials with:
 
 ```bash
 make repo_setup
@@ -218,30 +183,32 @@ import resolution, and local execution of the application code.
 | `test` | Test and lint harness. Includes `app`. |
 | `dev` | Full development harness. Includes `test` and DVC tooling. |
 
+### Local validation targets
+
+Prefer these Makefile targets for day-to-day local validation:
+
 ```bash
-# Synchronize the complete local development environment from uv.lock.
-uv sync --locked --group dev
-
-# Run the current lint gate.
-uv run --locked --group test ruff check .
-
-# Run unit tests while excluding integration tests.
-uv run --locked --group test pytest -m "not integration"
-
-# Activate the uv-managed virtual environment in a command-line session.
-source .venv/bin/activate
-
-# Optional cleanup of local Python artifacts.
-rm -rf .venv .pytest_cache .coverage htmlcov build dist *.egg-info
-find . -type d -name "__pycache__" -prune -exec rm -rf {} +
-
-# Execute the DVC pipeline.
-uv run --locked --group dev dvc repro
-
-# Launch the data API locally.
-# The API will be available at http://localhost:10000/docs.
-uv run --locked --group app uvicorn src.api.main:app --reload --port 10000
+make sync
+make lock-check
+make lint
+make test
+make ci
 ```
+
+`make ci` chains the lock check, Ruff linting, and unit tests while excluding
+integration tests. This mirrors the local validation path used by CI without
+requiring Docker services.
+
+Useful maintenance targets:
+
+```bash
+make clean
+make clean_env
+```
+
+`make clean` removes local Python caches and test artifacts only. It does not
+remove Docker volumes. Use `make clean_env` only when you want to recreate the
+uv-managed virtual environment from scratch.
 
 ## MLOps setup
 
@@ -253,25 +220,19 @@ uv run --locked --group app uvicorn src.api.main:app --reload --port 10000
 > the stack. The file contains Docker Compose variables, Makefile defaults,
 > local credentials, and optional remote MLflow/DagsHub settings.
 
-### 1. 🐳 Service containerization
+### 1. Docker engine setup
 
-We use **Docker** to simulate our production environment.
-
-#### Docker on a virtual machine with Ubuntu distribution
-
-> It is recommended to use a Docker engine directly on an Ubuntu virtual machine.
+For a first Docker installation on Ubuntu, install Docker Engine and add your
+user to the Docker group. This remains a host-level prerequisite and is not
+wrapped in the project Makefile.
 
 ```bash
-# Add official GPG key for Docker distribution.
 sudo apt update
 sudo apt install ca-certificates curl gnupg lsb-release -y
-
-# Add official GPG key for Docker distribution.
 sudo mkdir -m 0755 -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
   sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
-# Add official Docker repository.
 echo \
   "deb [arch=$(dpkg --print-architecture) \
   signed-by=/etc/apt/keyrings/docker.gpg] \
@@ -279,77 +240,58 @@ echo \
   $(lsb_release -cs) stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Update packages list and install Docker components.
 sudo apt update
 sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
-
-# Add current user authorization to Docker group.
 sudo usermod -aG docker $USER
 newgrp docker
 ```
 
-#### Optional local Docker Desktop with a virtual machine hypervisor
+Docker Desktop can also be used during development on Windows, macOS, or Linux.
 
-> As an alternative option, Docker Desktop can be used with additional support during the development phase.
+### 2. Docker Compose operation targets
 
-Installation guide: [Windows](https://docs.docker.com/desktop/setup/install/windows-install/) / [Mac](https://docs.docker.com/desktop/setup/install/mac-install/) / [Linux](https://docs.docker.com/desktop/setup/install/linux/)
-
-#### Operation commands
-
-> All these unit actions are consolidated in the Makefile.
-
-| Target | Description |
-|--------|-------------|
-| `sync` | Sync the local uv environment from `uv.lock`. |
-| `lock-check` | Check that `uv.lock` is consistent with `pyproject.toml`. |
-| `lint` | Run Ruff checks. |
-| `test` | Run unit tests while excluding integration tests. |
-| `ci` | Run local CI checks. |
-| `compose-config` | Validate Docker Compose configuration. |
-| `bootstrap` | Initialize bootstrap dependencies. |
-| `repo_setup` | Configure Git identity and DVC S3 credentials. |
-| `build` | Build Docker images for all profiles. |
-| `rebuild_full` | Rebuild Docker images and fully restart platform services. |
-| `start` | Start Docker services for the selected profile (`PROFILE=all/mlflow/airflow/monitoring/api/ptf`). |
-| `stop` | Stop Docker services for the selected profile. |
-| `logs` | Show Docker Compose logs for `SERVICE`. |
-| `sim_api_loop` | Simulate 10 API stop/start cycles with a 5-second interval. |
-| `sim_api_down` | Simulate a temporary API outage for 2 minutes. |
-| `sim_api_req` | Simulate response status mix and request volume on `/predictions/{counter}`. |
-| `clean` | Remove local Python caches and test artifacts only. |
-| `clean_env` | Remove the uv-managed virtual environment. |
-| `clean_full` | Remove Docker artifacts, including images, volumes, and networks. |
-| `help` | Show Makefile help. |
+The project is assumed to be cloned when running operational commands. Prefer
+Makefile targets for project-level Docker operations:
 
 ```bash
-# Validate the complete Docker Compose configuration.
 make compose-config
-
-# Build every Docker image.
 make build
+make ops
+```
 
-# Start all permanent platform services.
-make start PROFILE=ptf
+`make ops` validates the Compose configuration and starts the default platform
+profile. The default profile is `ptf`, which combines MLflow, Airflow,
+monitoring, and API services.
 
-# Start only the API profile.
+Targeted operations remain available when needed:
+
+```bash
 make start PROFILE=api
-
-# Show API logs.
+make stop PROFILE=api
 make logs SERVICE=api-dev
-
-# Start a pipeline run in interactive mode.
-docker compose --profile ml up ml-ingest-dev
-docker compose --profile ml up ml-features-dev
-docker compose --profile ml up ml-models-dev
-
-# Stop everything, including networks, while keeping database volumes.
-docker compose --profile all down
-
-# Stop everything and remove all images, volumes, networks, and orphan items.
+make rebuild_full
 make clean_full
 ```
 
-### 2. 📈 Experience tracker
+`make start` uses `docker compose up -d` so it works from a clean environment
+where containers have not been created yet. `make clean_full` is intentionally
+destructive: it removes Docker images, volumes, and networks.
+
+For one-off ML pipeline containers, run the existing Compose services directly:
+
+```bash
+docker compose --profile ml up ml-ingest-dev
+docker compose --profile ml up ml-features-dev
+docker compose --profile ml up ml-models-dev
+```
+
+The API is exposed at:
+
+```text
+http://localhost:10000/docs
+```
+
+### 3. 📈 Experience tracker
 
 We use **MLflow** to record **metrics**, **params**, and training/prediction
 **artifacts** (scikit-learn pipeline, autoregressive transformer, train/test
@@ -391,7 +333,7 @@ MLFLOW_TRACKING_USERNAME="[replace_me]"
 MLFLOW_TRACKING_PASSWORD="[replace_me]"
 ```
 
-### 3. 🧩 Multi-counter orchestration
+### 4. 🧩 Multi-counter orchestration
 
 - The environment configuration is mounted read-only in the Airflow Init container into `/opt/airflow/config/` (repo source: `./docker/dev/airflow/`). It configures especially:
   - The host repository root, to adjust to your production or development environment.
@@ -416,7 +358,7 @@ MLFLOW_TRACKING_PASSWORD="[replace_me]"
   - Every day, for each configured counter, trigger `init` then `daily`.
   - The `init` run is cheap if already done because it is short-circuited.
 
-### 4. 🧩 Monitoring and alerting
+### 5. 🧩 Monitoring and alerting
 
 The project has defined:
 

--- a/README.md
+++ b/README.md
@@ -46,55 +46,12 @@ avr25-mle-trafic-cycliste/
 ├── pyproject.toml      <- Python project, dependency groups, pytest, coverage, and Ruff configuration
 ├── uv.lock             <- uv lockfile for the local development environment
 ├── data                <- Data shared with host (read/write)
-│   ├── raw             <- Original, immutable data dumps (e.g., external sources)
-│   ├── interim         <- Intermediate data derived from raw (goal-specific)
-│   ├── processed       <- Processed data (e.g., feature-enriched)
-│   └── final           <- Final stage data (e.g., train/test and predictions)
 ├── logs                <- Logs shared with host (read/write)
-│   ├── ml              <- ML pipeline logs
-│   ├── api             <- Data API logs
-│   ├── scheduler       <- Airflow scheduler logs
-│   └── dag[...]        <- Unit DAG run logs
 ├── models              <- Model artifacts shared with host (read/write)
-│   └── ...
 ├── references          <- Data dictionaries, manuals, other explanatory material
-│   └── ...
-├── src/                <- All source code used in this project
-│   ├── airflow/        <- Airflow orchestration management
-│   │   ├── dags        <- Orchestrator DAGs code shared with host
-│   │   │   ├── bike_traffic_pipeline_dag.py
-│   │   │   └── bike_traffic_orchestrator_dag.py
-│   │   │   ├── common
-│   │   │   │   └── utils.py
-│   │   ├── config      <- Orchestrator config shared with host (read-only)
-│   │   │   └── bike_dag_config.json
-│   ├── api/            <- FastAPI service (prediction readout)
-│   │   └── main.py
-│   └── ml/             <- Machine learning pipeline
-│       ├── ingest      <- Scripts to ingest initial raw data or daily data
-│       │   ├── data_utils.py
-│       │   └── import_raw_data.py
-│       ├── features    <- Scripts to turn raw data into modeling-ready data
-│       │   ├── features_utils.py
-│       │   └── build_features.py
-│       └── models      <- Train models and compute batch predictions
-│           ├── models_utils.py
-│           └── train_and_predict.py
+├── src/                <- API, Airflow DAGs, and ML pipeline source code
 ├── docker/             <- Container architecture
-│   ├── dev/            <- Development setup
-│   │   ├── grafana/    <- Config for Grafana dashboards and provisioning
-│   │   ├── prometheus/ <- Config for Prometheus targets and general configuration
-│   │   ├── airflow/    <- Config and DAGs for Airflow
-│   │   ├── mlflow/     <- Custom Docker image for MLflow service
-│   │   ├── api/        <- Custom Docker image for API service
-│   │   └── ml/         <- Custom Docker images for ML pipeline services
-│   └── prod/           <- Production setup
-│       └── ...
-└── tests/
-    ├── unitary/        <- Unit tests
-    │   └── ...
-    └── integration/    <- Integration tests
-        └── ...
+└── tests/              <- Unit and integration tests
 ```
 
 ## ⚙️ Installation
@@ -119,8 +76,6 @@ wsl --install -d Ubuntu
 ```
 
 #### Linux bootstrap dependencies
-
-All commands in this README are provided from a Linux operating system point of view.
 
 ```bash
 sudo apt update
@@ -169,11 +124,9 @@ make repo_setup
 
 ## 🚀 DevOps setup
 
-> This section covers the project setup as a monolithic architecture from a DevOps point of view.
-
-This repository is not packaged as a Python distribution. The local Python environment
-is managed by uv and is used for developer tooling, static analysis, tests, Pylance
-import resolution, and local execution of the application code.
+This repository is not packaged as a Python distribution. The local Python
+environment is managed by uv and is used for developer tooling, static analysis,
+tests, Pylance import resolution, and local execution of the application code.
 
 ### uv dependency groups
 
@@ -222,30 +175,15 @@ uv-managed virtual environment from scratch.
 
 ### 1. Docker engine setup
 
-For a first Docker installation on Ubuntu, install Docker Engine and add your
-user to the Docker group. This remains a host-level prerequisite and is not
-wrapped in the project Makefile.
+For a first Docker installation on Ubuntu, use the dedicated Makefile target
+after cloning the repository:
 
 ```bash
-sudo apt update
-sudo apt install ca-certificates curl gnupg lsb-release -y
-sudo mkdir -m 0755 -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-  sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-echo \
-  "deb [arch=$(dpkg --print-architecture) \
-  signed-by=/etc/apt/keyrings/docker.gpg] \
-  https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
-sudo usermod -aG docker $USER
-newgrp docker
+make docker-install
 ```
 
+This installs Docker Engine, the Compose plugin, and adds the current user to
+the `docker` group. Open a new shell, or run `newgrp docker`, before using Docker.
 Docker Desktop can also be used during development on Windows, macOS, or Linux.
 
 ### 2. Docker Compose operation targets
@@ -277,12 +215,13 @@ make clean_full
 where containers have not been created yet. `make clean_full` is intentionally
 destructive: it removes Docker images, volumes, and networks.
 
-For one-off ML pipeline containers, run the existing Compose services directly:
+For one-off ML pipeline containers, use the dedicated targets:
 
 ```bash
-docker compose --profile ml up ml-ingest-dev
-docker compose --profile ml up ml-features-dev
-docker compose --profile ml up ml-models-dev
+make ml-ingest
+make ml-features
+make ml-models
+make ml-pipeline
 ```
 
 The API is exposed at:
@@ -300,10 +239,10 @@ splits, predictions, metrics, and hyperparameters).
 The MLflow-related environment variables are centralized in `.env.template` and
 should be customized in your local `.env` file.
 
-#### Local MLflow service
+#### Mode 1: Docker Compose MLflow service
 
-The default `.env.template` values target the local Docker Compose MLflow and
-MinIO services from inside the Compose network:
+This is the default MLOps mode. The default `.env.template` values target the
+local Docker Compose MLflow and MinIO services from inside the Compose network:
 
 ```bash
 MLFLOW_TRACKING_URI="http://mlflow-server:5000"
@@ -312,8 +251,33 @@ AWS_ACCESS_KEY_ID="minio"
 AWS_SECRET_ACCESS_KEY="[replace_me]"
 ```
 
-For host-side commands outside Docker Compose, use the exposed local endpoints in
-your shell or local `.env` when needed:
+Start it with the platform services:
+
+```bash
+make ops
+```
+
+#### Mode 2: Host-side MLflow server for data science experiments
+
+This mode is useful for preliminary local data science experiments without the
+full Docker Compose stack. Start a host-side MLflow server with:
+
+```bash
+make mlflow-host
+```
+
+By default, it starts on `http://127.0.0.1:5000` with a local SQLite backend and
+local `./mlruns` artifact directory. Override these values if needed:
+
+```bash
+make mlflow-host \
+  MLFLOW_HOST_PORT=5010 \
+  MLFLOW_BACKEND_STORE=sqlite:///mlflow.db \
+  MLFLOW_ARTIFACT_ROOT=./mlruns
+```
+
+For host-side scripts targeting the Compose MLflow service, use the exposed
+Compose endpoint instead:
 
 ```bash
 MLFLOW_TRACKING_URI="http://127.0.0.1:5001"
@@ -322,10 +286,10 @@ AWS_ACCESS_KEY_ID="minio"
 AWS_SECRET_ACCESS_KEY="[replace_me]"
 ```
 
-#### DagsHub remote MLflow service
+#### Mode 3: DagsHub remote MLflow service
 
-To use the DagsHub remote service instead of the local MLflow container, override
-these values in your local `.env` or shell session:
+To use the DagsHub remote service instead of local MLflow, override these values
+in your local `.env` or shell session:
 
 ```bash
 MLFLOW_TRACKING_URI="https://dagshub.com/zheddhe/avr25-mle-trafic-cycliste.mlflow"

--- a/README.md
+++ b/README.md
@@ -155,11 +155,7 @@ pipx ensurepath
 pipx install uv
 ```
 
-### 🔧 Repository cloning and DVC setup (one-time init)
-
-Please refer to DagsHub remote setup actions. Example steps:
-
-- Git setup and cloning
+### 🔧 Repository cloning and local environment setup
 
 ```bash
 # Set up your local Git identity and clone the repository.
@@ -182,12 +178,28 @@ git clone git@github.com:zheddhe/avr25-mle-trafic-cycliste.git
 cd avr25-mle-trafic-cycliste
 ```
 
-- DVC setup
+Create your local `.env` file from the tracked template before running Makefile
+or Docker Compose commands:
 
 ```bash
-# Set up your personal credentials for DagsHub.
-dvc remote modify origin --local access_key_id [...]
-dvc remote modify origin --local secret_access_key [...]
+cp .env.template .env
+```
+
+Then replace every `[replace_me]` value in `.env` with your local values. The
+`.env` file is intentionally not tracked by Git because it may contain secrets.
+Docker Compose reads `.env` automatically from the repository root. For shell
+commands such as `make repo_setup`, load it explicitly when needed:
+
+```bash
+set -a
+source .env
+set +a
+```
+
+DVC setup can then be performed through the Makefile:
+
+```bash
+make repo_setup
 ```
 
 ## 🚀 DevOps setup
@@ -237,7 +249,9 @@ uv run --locked --group app uvicorn src.api.main:app --reload --port 10000
 > [![Docker Compose Overview](references/Docker_Compose_Overview.drawio.png)](https://drive.google.com/file/d/1-C0uL1whFDYXiqkDn20CK2AUF_-S3Ytp/view?usp=drive_link)
 > [![Docker Compose Monitoring](references/Docker_Compose_Monitoring.drawio.png)](https://drive.google.com/file/d/14DbcNiD3w7nrdkPiIymbMpX0-vzXRupW/view?usp=drive_link)
 >
-> You'll need to create and customize your own **.env** file to populate environment variables that are required at startup. A template file `.env.template` is provided.
+> Create and customize your own `.env` file from `.env.template` before starting
+> the stack. The file contains Docker Compose variables, Makefile defaults,
+> local credentials, and optional remote MLflow/DagsHub settings.
 
 ### 1. 🐳 Service containerization
 
@@ -284,41 +298,46 @@ Installation guide: [Windows](https://docs.docker.com/desktop/setup/install/wind
 
 > All these unit actions are consolidated in the Makefile.
 
-| Target       | Description |
-|--------------|-------------|
-| bootstrap    | Initialize bootstrap dependencies. |
-| repo_setup   | Configure the DVC S3 remote and GitHub credentials. |
-| rebuild_full | Rebuild Docker images and fully restart services. |
-| start        | Start Docker services for the selected profile (`PROFILE=all/mlflow/airflow/monitoring/api/ptf`). |
-| stop         | Stop Docker services for the selected profile (`PROFILE=all/mlflow/airflow/monitoring/api/ptf`). |
-| sim_api_loop | Simulate 10 API stop/start cycles with a 5-second interval. |
-| sim_api_down | Simulate a temporary API outage for 2 minutes. |
-| sim_api_req  | Simulate response status mix and request volume on `/predictions/{counter}`. |
-| clean_full   | Remove Docker artifacts, including images, volumes, and networks. |
-| help         | Show Makefile help. |
+| Target | Description |
+|--------|-------------|
+| `sync` | Sync the local uv environment from `uv.lock`. |
+| `lock-check` | Check that `uv.lock` is consistent with `pyproject.toml`. |
+| `lint` | Run Ruff checks. |
+| `test` | Run unit tests while excluding integration tests. |
+| `ci` | Run local CI checks. |
+| `compose-config` | Validate Docker Compose configuration. |
+| `bootstrap` | Initialize bootstrap dependencies. |
+| `repo_setup` | Configure Git identity and DVC S3 credentials. |
+| `build` | Build Docker images for all profiles. |
+| `rebuild_full` | Rebuild Docker images and fully restart platform services. |
+| `start` | Start Docker services for the selected profile (`PROFILE=all/mlflow/airflow/monitoring/api/ptf`). |
+| `stop` | Stop Docker services for the selected profile. |
+| `logs` | Show Docker Compose logs for `SERVICE`. |
+| `sim_api_loop` | Simulate 10 API stop/start cycles with a 5-second interval. |
+| `sim_api_down` | Simulate a temporary API outage for 2 minutes. |
+| `sim_api_req` | Simulate response status mix and request volume on `/predictions/{counter}`. |
+| `clean` | Remove local Python caches and test artifacts only. |
+| `clean_env` | Remove the uv-managed virtual environment. |
+| `clean_full` | Remove Docker artifacts, including images, volumes, and networks. |
+| `help` | Show Makefile help. |
 
 ```bash
-# 1) Initialize and build the Docker images.
-docker compose --profile all build
+# Validate the complete Docker Compose configuration.
+make compose-config
 
-# 2) Start all backend services.
-# profile mlflow: server / postgres / minio / mc-init in background
-# profile airflow: webserver / worker / scheduler / init / postgres / redis / mailhog in background
-# profile monitoring: grafana / prometheus / cadvisor / node-exporter
-docker compose --profile mlflow up -d
-docker compose --profile airflow up -d
-docker compose --profile monitoring up -d
+# Build every Docker image.
+make build
 
-# 3) Start all permanent business services in background.
-# profile api: data API service
-docker compose --profile api up -d
+# Start all permanent platform services.
+make start PROFILE=ptf
 
-# The API will be available at http://localhost:10000/docs.
+# Start only the API profile.
+make start PROFILE=api
 
-# NB: profile ptf (platform) combines mlflow, airflow, monitoring, and API profiles.
+# Show API logs.
+make logs SERVICE=api-dev
 
-# 4) Start a pipeline run in interactive mode.
-# profile ml: raw ingestion / features engineering / train and predict services
+# Start a pipeline run in interactive mode.
 docker compose --profile ml up ml-ingest-dev
 docker compose --profile ml up ml-features-dev
 docker compose --profile ml up ml-models-dev
@@ -327,7 +346,7 @@ docker compose --profile ml up ml-models-dev
 docker compose --profile all down
 
 # Stop everything and remove all images, volumes, networks, and orphan items.
-docker compose --profile all down -v --rmi all && docker system prune -f
+make clean_full
 ```
 
 ### 2. 📈 Experience tracker
@@ -336,27 +355,40 @@ We use **MLflow** to record **metrics**, **params**, and training/prediction
 **artifacts** (scikit-learn pipeline, autoregressive transformer, train/test
 splits, predictions, metrics, and hyperparameters).
 
-#### DagsHub remote service
+The MLflow-related environment variables are centralized in `.env.template` and
+should be customized in your local `.env` file.
+
+#### Local MLflow service
+
+The default `.env.template` values target the local Docker Compose MLflow and
+MinIO services from inside the Compose network:
 
 ```bash
-# Configure environment variables.
-# It is recommended to store this within a .env.local file so that you can source it.
-export MLFLOW_TRACKING_URI=https://dagshub.com/zheddhe/avr25-mle-trafic-cycliste.mlflow
-export MLFLOW_TRACKING_USERNAME=<DagsHub ACCOUNT>
-export MLFLOW_TRACKING_PASSWORD=<DagsHub TOKEN, preferably over a personal password>
-# source .env.local
+MLFLOW_TRACKING_URI="http://mlflow-server:5000"
+MLFLOW_S3_ENDPOINT_URL="http://mlflow-minio:9000"
+AWS_ACCESS_KEY_ID="minio"
+AWS_SECRET_ACCESS_KEY="[replace_me]"
 ```
 
-#### Local service
+For host-side commands outside Docker Compose, use the exposed local endpoints in
+your shell or local `.env` when needed:
 
 ```bash
-# Configure environment variables.
-# It is recommended to store this within a .env.local file so that you can source it.
-export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
-export MLFLOW_S3_ENDPOINT_URL=http://127.0.0.1:9000
-export AWS_ACCESS_KEY_ID=minio
-export AWS_SECRET_ACCESS_KEY=minio123
-# source .env.local
+MLFLOW_TRACKING_URI="http://127.0.0.1:5001"
+MLFLOW_S3_ENDPOINT_URL="http://127.0.0.1:9000"
+AWS_ACCESS_KEY_ID="minio"
+AWS_SECRET_ACCESS_KEY="[replace_me]"
+```
+
+#### DagsHub remote MLflow service
+
+To use the DagsHub remote service instead of the local MLflow container, override
+these values in your local `.env` or shell session:
+
+```bash
+MLFLOW_TRACKING_URI="https://dagshub.com/zheddhe/avr25-mle-trafic-cycliste.mlflow"
+MLFLOW_TRACKING_USERNAME="[replace_me]"
+MLFLOW_TRACKING_PASSWORD="[replace_me]"
 ```
 
 ### 3. 🧩 Multi-counter orchestration
@@ -395,13 +427,12 @@ The project has defined:
   - API service down for a configurable period of time.
   - API service instability, such as restart loops.
 
-#### Push Gateway configuration
+The Pushgateway behavior is controlled by the `DISABLE_METRICS_PUSH` variable in
+`.env`:
 
 ```bash
 # Inhibit push metrics to Pushgateway: 1 = disabled, other values = enabled.
-# It is recommended to store this within a .env.local file so that you can source it.
-export DISABLE_METRICS_PUSH=1
-# source .env.local
+DISABLE_METRICS_PUSH=1
 ```
 
 ## 🤝 Team collaboration

--- a/README.md
+++ b/README.md
@@ -116,10 +116,38 @@ The `.env` file is intentionally not tracked by Git because it may contain
 secrets. Docker Compose reads `.env` automatically from the repository root.
 Makefile targets that need repository secrets can load it internally.
 
-Once `.env` is populated, configure Git identity and DVC credentials with:
+Configure local Git identity and DVC credentials with:
+
+```bash
+make git-setup
+make dvc-setup
+```
+
+`make dvc-setup` does not run `dvc init` on this repository because DVC is
+already initialized and `.dvc/config` is versioned. It only writes local DVC S3
+credentials to `.dvc/config.local`, which is ignored by `.dvc/.gitignore`.
+
+Use this convenience target when both steps are needed:
 
 ```bash
 make repo_setup
+```
+
+The versioned DVC remote is defined in `.dvc/config`:
+
+```ini
+[core]
+    remote = origin
+['remote "origin"']
+    url = s3://dvc
+    endpointurl = https://dagshub.com/zheddhe/avr25-mle-trafic-cycliste.s3
+```
+
+The matching local `.env` variables are:
+
+```bash
+DAGSHUB_ACCESS_KEY_ID="[replace_me]"
+DAGSHUB_SECRET_ACCESS_KEY="[replace_me]"
 ```
 
 ## 🚀 DevOps setup
@@ -381,4 +409,4 @@ The CI environment uses uv dependency groups directly and runs Ruff before pytes
 - Rémy Canal – [@remy.canal](mailto:remy.canal@live.fr)  
 - Elias Djouadi – [@elias.djouadi](mailto:elias.djouadi@gmail.com)
 - Koladé Houessou – [@kolade.houessou](mailto:koladehouessou@gmail.com)
-- Sofia Bouizzoul - [@sofia.bouizzoul](mailto:sofiabouizzoul98@gmail.com)
+- Sofia Bouizzoul - [@sofia.bouizzoul](mailto:sofia.bouizzoul@gmail.com)


### PR DESCRIPTION
## Summary

Stabilizes the root Makefile around uv-based local validation, Docker Compose operations, local environment variables, and common local MLOps operations. The README is rationalized to distinguish pre-clone bootstrap from post-clone Makefile-driven setup.

## Changes

- Rework Makefile comments and target descriptions in English.
- Add explicit variables for `UV`, `DOCKER_COMPOSE`, `ENV_FILE`, `PROFILE`, `SERVICE`, API load test parameters, Docker install values, and MLflow host defaults.
- Add local validation targets aligned with CI:
  - `sync`
  - `lock-check`
  - `lint`
  - `test`
  - `ci`
- Add `env` and `setup` targets for post-clone local setup.
- Add `compose-config` to validate Docker Compose with `docker compose --profile all config`.
- Keep bootstrap uv-only and Nox-free.
- Add `docker-install` to install Docker Engine and the Compose plugin on Ubuntu.
- Use `docker compose --profile $(PROFILE) up -d` in `start` so containers can be created from a clean environment.
- Keep Docker profiles and service names unchanged.
- Add `logs` for the selected Docker service.
- Add one-off ML operation targets:
  - `ml-ingest`
  - `ml-features`
  - `ml-models`
  - `ml-pipeline`
- Add `mlflow-host` for host-side MLflow data science experiments.
- Make local cleanup explicit:
  - `clean` removes local Python caches and test artifacts only.
  - `clean_env` removes `.venv` only.
  - `clean_full` remains the explicit Docker destructive cleanup target.
- Run API load simulation through `uv run --locked --group test`.
- Update `.env.template` to document Makefile-related variables and MLflow settings.
- Use consistent `[replace_me]` placeholders for sensitive or user-specific local values.
- Default `DISABLE_METRICS_PUSH=1` for safe local commands and tests.
- Update README to prefer Makefile targets once the repository is cloned.
- Document MLflow in three modes:
  - Docker Compose service.
  - Host-side local experimentation server.
  - DagsHub remote service.

## Deliberately out of scope

- No Docker Compose service/profile changes.
- No Python dependency version changes.
- No functional Python code changes.
- No CI workflow changes.

## Validation to run before merge

```bash
make help
make env
make setup
make repo_setup
make sync
make lock-check
make lint
make test
make ci
make compose-config