### PR TITLE
[STORY] Phase 6 - Centralize runtime ports and Compose service exposure

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,11 +16,35 @@ GIT_EMAIL="[replace_me]"
 DAGSHUB_ACCESS_KEY_ID="[replace_me]"
 DAGSHUB_SECRET_ACCESS_KEY="[replace_me]"
 
+# =================== Runtime host ports =======================================
+# Business apps / application APIs: 10000-10999.
+API_HOST_PORT=10000
+
+# Orchestration / workflow tools: 12000-12999.
+AIRFLOW_HOST_PORT=12080
+AIRFLOW_FLOWER_HOST_PORT=12555
+
+# Tracking and artifact systems: 13000-13999.
+MINIO_API_HOST_PORT=13000
+MLFLOW_HOST_PORT=13001
+MINIO_CONSOLE_HOST_PORT=13002
+
+# Observability and alerting: 14000-14999.
+PROMETHEUS_HOST_PORT=14090
+PUSHGATEWAY_HOST_PORT=14091
+CADVISOR_HOST_PORT=14200
+GRAFANA_HOST_PORT=14300
+ALERTMANAGER_HOST_PORT=14093
+
+# Dev-only helpers and local debug tools: 15000-15999.
+MAILHOG_SMTP_HOST_PORT=15025
+MAILHOG_UI_HOST_PORT=15080
+
 # =================== Makefile defaults ========================================
 # Used by: make start/stop/logs/sim_api_req
 PROFILE="ptf"
 SERVICE="api-dev"
-URL="http://localhost:10000"
+URL="http://localhost:${API_HOST_PORT}"
 N=100
 P_OK=0.80
 API_USER="user1"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ tests, Pylance import resolution, and local execution of the application code.
 ### uv dependency groups
 
 | Group | Purpose |
-|-------|---------|
+| :---- | :------ |
 | `app` | Local application surface: API, DAGs, ML scripts, MLflow, metrics, and orchestration imports. |
 | `test` | Test and lint harness. Includes `app`. |
 | `dev` | Full development harness. Includes `test` and DVC tooling. |
@@ -246,16 +246,16 @@ destructive: it removes Docker images, volumes, and networks.
 For one-off ML pipeline containers, use the dedicated targets:
 
 ```bash
-make ml-ingest
-make ml-features
-make ml-models
-make ml-pipeline
+make mlops-ingest
+make mlops-features
+make mlops-models
+make mlops-pipeline
 ```
 
 The API is exposed at:
 
 ```text
-http://localhost:10000/docs
+http://localhost:[API_HOST_PORT]/docs
 ```
 
 ### 3. 📈 Experience tracker
@@ -285,34 +285,26 @@ Start it with the platform services:
 make ops
 ```
 
-#### Mode 2: Host-side MLflow server for data science experiments
+#### Mode 2: Host-side MLflow local server and backend data runs
 
 This mode is useful for preliminary local data science experiments without the
-full Docker Compose stack. Start a host-side MLflow server with:
+full Docker Compose stack.
+
+It populates `./mlruns` artifact directory by unsetting MLFLOW_TRACKING_URI during standalone local debugging runs.
 
 ```bash
-make mlflow-host
+make local-ingest
+make local-features
+make local-models
+make local-pipeline
 ```
 
-By default, it starts on `http://127.0.0.1:5000` with a local SQLite backend and
-local `./mlruns` artifact directory. Override these values if needed:
+A MLflow local server can visualize the artifact directory afterwards.
 
 ```bash
-make mlflow-host \
-  MLFLOW_HOST_PORT=5010 \
-  MLFLOW_BACKEND_STORE=sqlite:///mlflow.db \
-  MLFLOW_ARTIFACT_ROOT=./mlruns
+make mlflow-local
 ```
 
-For host-side scripts targeting the Compose MLflow service, use the exposed
-Compose endpoint instead:
-
-```bash
-MLFLOW_TRACKING_URI="http://127.0.0.1:5001"
-MLFLOW_S3_ENDPOINT_URL="http://127.0.0.1:9000"
-AWS_ACCESS_KEY_ID="minio"
-AWS_SECRET_ACCESS_KEY="[replace_me]"
-```
 
 #### Mode 3: DagsHub remote MLflow service
 

--- a/README.md
+++ b/README.md
@@ -252,11 +252,8 @@ make mlops-models
 make mlops-pipeline
 ```
 
-The API is exposed at:
-
-```text
-http://localhost:[API_HOST_PORT]/docs
-```
+By default, the API is exposed at `http://localhost:10000/docs`.
+Override `API_HOST_PORT` in `.env` to use another host port.
 
 ### 3. 📈 Experience tracker
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -141,7 +141,7 @@ services:
       context: .
       dockerfile: ./docker/dev/api/Dockerfile
     ports:
-      - "10000:10000"
+      - "${API_HOST_PORT:-10000}:10000"
     restart: unless-stopped
     volumes:
       - ./data:/app/data
@@ -183,8 +183,8 @@ services:
     volumes:
       - mlflow-minio-data:/data
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${MINIO_API_HOST_PORT:-13000}:9000"
+      - "${MINIO_CONSOLE_HOST_PORT:-13002}:9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
@@ -232,7 +232,7 @@ services:
       AWS_DEFAULT_REGION: us-east-1
       MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
     ports:
-      - "5001:5000"
+      - "${MLFLOW_HOST_PORT:-13001}:5000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000"]
       interval: 5s
@@ -272,8 +272,6 @@ services:
 
   airflow-redis:
     image: redis:latest
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -340,7 +338,7 @@ services:
         condition: service_completed_successfully
     command: ["webserver"]
     ports:
-      - "8080:8080"
+      - "${AIRFLOW_HOST_PORT:-12080}:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 10s
@@ -452,7 +450,7 @@ services:
         condition: service_completed_successfully
     command: ["celery", "flower"]
     ports:
-      - "5555:5555"
+      - "${AIRFLOW_FLOWER_HOST_PORT:-12555}:5555"
     restart: unless-stopped
     healthcheck:
       test:
@@ -474,7 +472,7 @@ services:
     image: prom/prometheus:v2.54.1
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_HOST_PORT:-14090}:9090"
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=15d
@@ -490,7 +488,7 @@ services:
     restart: unless-stopped
     # user: "472"
     ports:
-      - "3000:3000"
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
@@ -510,7 +508,7 @@ services:
     restart: unless-stopped
     privileged: true
     ports:
-      - "9200:8080"
+      - "${CADVISOR_HOST_PORT:-14200}:8080"
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -523,7 +521,7 @@ services:
   monitoring-pushgateway:
     image: prom/pushgateway:v1.9.0
     ports:
-      - "9091:9091"
+      - "${PUSHGATEWAY_HOST_PORT:-14091}:9091"
     networks:
       - mlops_net
     profiles: ["monitoring", "all", "ptf"]
@@ -533,7 +531,7 @@ services:
     volumes:
       - ./docker/dev/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
     ports:
-      - "9093:9093"
+      - "${ALERTMANAGER_HOST_PORT:-14093}:9093"
     networks:
       - mlops_net
     profiles: ["all", "monitoring", "ptf"]
@@ -541,10 +539,9 @@ services:
   monitoring-mailhog:
     image: mailhog/mailhog
     ports:
-      - "1025:1025"
-      - "8025:8025"
+      - "${MAILHOG_SMTP_HOST_PORT:-15025}:1025"
+      - "${MAILHOG_UI_HOST_PORT:-15080}:8025"
     restart: unless-stopped
     networks:
       - mlops_net
     profiles: ["all", "monitoring", "ptf"]
-

--- a/docs/ports-and-services.md
+++ b/docs/ports-and-services.md
@@ -10,7 +10,7 @@ networks. The variables below only control ports published on the host machine.
 ## Port ranges
 
 | Range | Responsibility |
-|-------|----------------|
+| ----- | -------------- |
 | `10000-10999` | Business applications and application APIs |
 | `11000-11999` | Local business debug endpoints, if needed later |
 | `12000-12999` | Orchestration and workflow tools |
@@ -21,7 +21,7 @@ networks. The variables below only control ports published on the host machine.
 ## Host-exposed services
 
 | Variable | Default | Service | Internal port | Reason |
-|----------|---------|---------|---------------|--------|
+| -------- | ------- | ------- | ------------- | ------ |
 | `API_HOST_PORT` | `10000` | `api-dev` | `10000` | FastAPI prediction API and OpenAPI docs |
 | `AIRFLOW_HOST_PORT` | `12080` | `airflow-webserver` | `8080` | Airflow UI for local DAG operations |
 | `AIRFLOW_FLOWER_HOST_PORT` | `12555` | `airflow-flower` | `5555` | Celery worker monitoring during local development |
@@ -41,7 +41,7 @@ networks. The variables below only control ports published on the host machine.
 With the default `.env.template` values, the main local URLs are:
 
 | Service | URL |
-|---------|-----|
+| ------- | --- |
 | FastAPI docs | `http://localhost:10000/docs` |
 | Airflow UI | `http://localhost:12080` |
 | Flower UI | `http://localhost:12555` |
@@ -60,7 +60,7 @@ With the default `.env.template` values, the main local URLs are:
 The following services are intentionally not published on host ports:
 
 | Service | Reason |
-|---------|--------|
+| ------- | ------ |
 | `ml-ingest-dev` | One-off ML pipeline container triggered by Compose or Airflow |
 | `ml-features-dev` | One-off ML pipeline container triggered by Compose or Airflow |
 | `ml-models-dev` | One-off ML pipeline container triggered by Compose or Airflow |

--- a/docs/ports-and-services.md
+++ b/docs/ports-and-services.md
@@ -1,0 +1,90 @@
+# Runtime ports and service exposure
+
+This document describes the local Docker Compose host port strategy. It is a
+local development convention only. It does not represent a production security
+model.
+
+Docker services communicate through their internal container ports and Docker
+networks. The variables below only control ports published on the host machine.
+
+## Port ranges
+
+| Range | Responsibility |
+|-------|----------------|
+| `10000-10999` | Business applications and application APIs |
+| `11000-11999` | Local business debug endpoints, if needed later |
+| `12000-12999` | Orchestration and workflow tools |
+| `13000-13999` | Tracking and artifact systems |
+| `14000-14999` | Observability and alerting |
+| `15000-15999` | Development-only helpers and debug tools |
+
+## Host-exposed services
+
+| Variable | Default | Service | Internal port | Reason |
+|----------|---------|---------|---------------|--------|
+| `API_HOST_PORT` | `10000` | `api-dev` | `10000` | FastAPI prediction API and OpenAPI docs |
+| `AIRFLOW_HOST_PORT` | `12080` | `airflow-webserver` | `8080` | Airflow UI for local DAG operations |
+| `AIRFLOW_FLOWER_HOST_PORT` | `12555` | `airflow-flower` | `5555` | Celery worker monitoring during local development |
+| `MINIO_API_HOST_PORT` | `13000` | `mlflow-minio` | `9000` | S3-compatible artifact endpoint for host-side MLflow clients |
+| `MLFLOW_HOST_PORT` | `13001` | `mlflow-server` | `5000` | MLflow tracking UI and host-side MLflow clients |
+| `MINIO_CONSOLE_HOST_PORT` | `13002` | `mlflow-minio` | `9001` | MinIO browser console for local artifact debugging |
+| `PROMETHEUS_HOST_PORT` | `14090` | `monitoring-prometheus` | `9090` | Prometheus UI and query debugging |
+| `PUSHGATEWAY_HOST_PORT` | `14091` | `monitoring-pushgateway` | `9091` | Pushgateway UI and local metrics debugging |
+| `ALERTMANAGER_HOST_PORT` | `14093` | `monitoring-alertmanager` | `9093` | Alertmanager UI and alert routing debugging |
+| `CADVISOR_HOST_PORT` | `14200` | `monitoring-cadvisor` | `8080` | Container-level runtime metrics debugging |
+| `GRAFANA_HOST_PORT` | `14300` | `monitoring-grafana` | `3000` | Grafana dashboards |
+| `MAILHOG_SMTP_HOST_PORT` | `15025` | `monitoring-mailhog` | `1025` | Local SMTP capture endpoint |
+| `MAILHOG_UI_HOST_PORT` | `15080` | `monitoring-mailhog` | `8025` | MailHog web UI |
+
+## Local URLs
+
+With the default `.env.template` values, the main local URLs are:
+
+| Service | URL |
+|---------|-----|
+| FastAPI docs | `http://localhost:10000/docs` |
+| Airflow UI | `http://localhost:12080` |
+| Flower UI | `http://localhost:12555` |
+| MinIO API | `http://localhost:13000` |
+| MLflow UI | `http://localhost:13001` |
+| MinIO console | `http://localhost:13002` |
+| Prometheus UI | `http://localhost:14090` |
+| Pushgateway UI | `http://localhost:14091` |
+| Alertmanager UI | `http://localhost:14093` |
+| cAdvisor UI | `http://localhost:14200` |
+| Grafana UI | `http://localhost:14300` |
+| MailHog UI | `http://localhost:15080` |
+
+## Internal-only services
+
+The following services are intentionally not published on host ports:
+
+| Service | Reason |
+|---------|--------|
+| `ml-ingest-dev` | One-off ML pipeline container triggered by Compose or Airflow |
+| `ml-features-dev` | One-off ML pipeline container triggered by Compose or Airflow |
+| `ml-models-dev` | One-off ML pipeline container triggered by Compose or Airflow |
+| `mlflow-postgres` | MLflow internal metadata database |
+| `mlflow-mc-init` | One-off MinIO initialization helper |
+| `airflow-postgres` | Airflow internal metadata database |
+| `airflow-redis` | Airflow Celery broker, used only inside `airflow_net` |
+| `airflow-init` | One-off Airflow initialization helper |
+| `airflow-scheduler` | Internal Airflow scheduler process |
+| `airflow-worker` | Internal Airflow Celery worker process |
+
+`airflow-redis` used to publish `6379` on the host. It is now internal-only
+because no documented local workflow requires direct host access to the broker.
+
+## Validation
+
+The expected configuration validation command is:
+
+```bash
+make compose-config
+```
+
+It runs:
+
+```bash
+docker compose --profile all config
+```


### PR DESCRIPTION
## Summary

Implements the first Phase 6 runtime-topology story by centralizing Docker Compose host port exposure without changing service responsibilities or internal container ports.

## Changes

- Replace hardcoded host port mappings in `docker-compose.yaml` with `${*_HOST_PORT:-default}` variables.
- Move local host ports into documented ranges in `.env.template`.
- Add `docs/ports-and-services.md` with:
  - port range strategy,
  - host-exposed service table,
  - local URLs,
  - internal-only services,
  - validation command.
- Stop publishing `airflow-redis` on the host because it is only required inside `airflow_net`.

## Validation

- YAML structure was parsed locally for the updated `docker-compose.yaml`.
- Expected repository validation remains:

```bash
make compose-config
```

This should run:

```bash
docker compose --profile all config
```

## Notes

This PR intentionally avoids security hardening, user changes, secret refactoring, image changes, and network-topology refactoring beyond removing the undocumented Redis host exposure.

Closes #46