### PR TITLE
[STORY] Phase 7 - Introduce local production-like Compose runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 .PHONY: help bootstrap docker-install env setup git-setup dvc-setup
 .PHONY: repo-setup
 .PHONY: env-compose env-local env-dagshub
-.PHONY: sync lock-check lint test tests ci compose-config
+.PHONY: sync lock-check lint tests ci compose-config
 .PHONY: build ops start stop logs
 .PHONY: mlops-ingest mlops-features mlops-models mlops-pipeline dvc-pipeline
 .PHONY: local-ingest local-features local-models local-pipeline mlflow-local
@@ -182,8 +182,6 @@ lock-check: ## Check that uv.lock is consistent with pyproject.toml
 lint: ## Run Ruff checks
 	@$(call log_test,lint)
 	$(UV) run --locked --group test ruff check .
-
-test: tests ## Backward-compatible alias for tests
 
 tests: ## Run integration tests scope
 	@$(call log_test,integration-test)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 SHELL := /bin/bash
 .ONESHELL:
-# Error handling flags: immediate exit and exit on first pipe error.
 .SHELLFLAGS := -eu -o pipefail -c
-# Default make target.
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap docker-install env setup git-setup dvc-setup repo_setup
+.PHONY: help bootstrap docker-install env setup git-setup dvc-setup repo-setup
 .PHONY: env-compose env-local env-dagshub
 .PHONY: sync lock-check lint tests ci compose-config
 .PHONY: build rebuild_full ops start stop logs
@@ -18,6 +16,8 @@ UV ?= uv
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
 PROFILE ?= ptf
+DEV_PROFILE ?= $(PROFILE)
+PROD_PROFILE ?= ptf
 SERVICE ?= api-dev
 URL ?= http://localhost:10000
 N ?= 100
@@ -40,6 +40,9 @@ MLFLOW_BACKEND_STORE ?= ./mlruns
 log_test = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
 load_env = if [ -f "$(ENV_FILE)" ]; then set -a; source "$(ENV_FILE)"; set +a; fi
 check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
+
+include docker/dev/Makefile
+include docker/prod/Makefile
 
 help: ## Display this help
 	@awk ' \
@@ -185,55 +188,27 @@ tests: ## Run integration tests scope
 
 ci: lock-check lint tests ## Run local CI checks
 
-compose-config: env ## Validate the Docker Compose configuration
-	@$(call log_test,compose-config)
-	$(DOCKER_COMPOSE) --profile all config >/dev/null
+compose-config: dev-compose-config ## Validate the development Compose configuration
 
-build: env ## Build Docker images for all profiles
-	@$(call log_test,build)
-	$(DOCKER_COMPOSE) --profile all build
+build: dev-build ## Build development Docker images
 
-rebuild_full: env ## Rebuild Docker images and restart platform services
-	@$(call log_test,rebuild_full)
-	eval "$$($(MAKE) --no-print-directory env-compose)"
-	$(DOCKER_COMPOSE) --profile all build
-	$(DOCKER_COMPOSE) --profile all down
-	$(DOCKER_COMPOSE) --profile ptf up -d
+rebuild_full: dev-rebuild-full ## Rebuild development images and restart services
 
-ops: env ## Validate and start platform services with Compose MLflow variables
-	@$(call log_test,ops)
-	eval "$$($(MAKE) --no-print-directory env-compose)"
-	$(DOCKER_COMPOSE) --profile all config >/dev/null
-	$(DOCKER_COMPOSE) --profile $(PROFILE) up -d
+ops: dev-ops ## Start development platform services
 
-start: env ## Start Docker services for the selected profile
-	@$(call log_test,start PROFILE=$(PROFILE))
-	$(DOCKER_COMPOSE) --profile $(PROFILE) up -d
+start: dev-start ## Start development services for the selected profile
 
-stop: ## Stop Docker services for the selected profile
-	@$(call log_test,stop PROFILE=$(PROFILE))
-	$(DOCKER_COMPOSE) --profile $(PROFILE) stop
+stop: dev-stop ## Stop development services for the selected profile
 
-logs: ## Show Docker Compose logs for SERVICE
-	@$(call log_test,logs SERVICE=$(SERVICE))
-	$(DOCKER_COMPOSE) logs -f -t $(SERVICE)
+logs: dev-logs ## Follow development Docker Compose logs for SERVICE
 
-mlops-ingest: env ## Run the ML ingestion container once
-	@$(call log_test,mlops-ingest)
-	eval "$$($(MAKE) --no-print-directory env-compose)"
-	$(DOCKER_COMPOSE) --profile ml up ml-ingest-dev
+mlops-ingest: dev-mlops-ingest ## Run the development ML ingestion container once
 
-mlops-features: env ## Run the ML feature engineering container once
-	@$(call log_test,mlops-features)
-	eval "$$($(MAKE) --no-print-directory env-compose)"
-	$(DOCKER_COMPOSE) --profile ml up ml-features-dev
+mlops-features: dev-mlops-features ## Run the development ML feature container once
 
-mlops-models: env ## Run the ML training and prediction container once
-	@$(call log_test,mlops-models)
-	eval "$$($(MAKE) --no-print-directory env-compose)"
-	$(DOCKER_COMPOSE) --profile ml up ml-models-dev
+mlops-models: dev-mlops-models ## Run the development ML model container once
 
-mlops-pipeline: mlops-ingest mlops-features mlops-models ## Run the full one-off ML pipeline
+mlops-pipeline: dev-mlops-pipeline ## Run the full development ML pipeline
 
 dvc-pipeline: env ## Run the full DVC pipeline
 	@$(call log_test,dvc-pipeline)
@@ -295,10 +270,16 @@ sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
 	@$(call log_test,sim_api_loop)
 	for i in {1..10}; do \
 		echo "[restart $$i] stopping api-dev..."; \
-		$(DOCKER_COMPOSE) stop api-dev; \
+		$(DOCKER_COMPOSE) \
+			--env-file $(ENV_FILE) \
+			-f docker/dev/docker-compose.yaml \
+			-p trafic-cycliste-dev stop api-dev; \
 		sleep 2; \
 		echo "[restart $$i] starting api-dev..."; \
-		$(DOCKER_COMPOSE) up -d api-dev; \
+		$(DOCKER_COMPOSE) \
+			--env-file $(ENV_FILE) \
+			-f docker/dev/docker-compose.yaml \
+			-p trafic-cycliste-dev up -d api-dev; \
 		echo "[restart $$i] done, waiting 5s..."; \
 		sleep 5; \
 	done
@@ -306,9 +287,15 @@ sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
 
 sim_api_down: ## Simulate a temporary API outage for 2 minutes
 	@$(call log_test,sim_api_down)
-	$(DOCKER_COMPOSE) stop api-dev
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f docker/dev/docker-compose.yaml \
+		-p trafic-cycliste-dev stop api-dev
 	sleep 120
-	$(DOCKER_COMPOSE) up -d api-dev
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f docker/dev/docker-compose.yaml \
+		-p trafic-cycliste-dev up -d api-dev
 
 sim_api_req: ## Simulate traffic on /predictions/{counter}
 	@$(call log_test,sim_api_req)
@@ -333,8 +320,12 @@ clean_env: ## Remove the uv-managed virtual environment
 	@$(call log_test,clean_env)
 	rm -rf .venv
 
-clean_full: ## Remove Docker artifacts, including images, volumes, and networks
+clean_full: ## Remove development Docker artifacts, including images and volumes
 	@$(call log_test,clean_full)
-	$(DOCKER_COMPOSE) --profile all down -v --rmi all
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f docker/dev/docker-compose.yaml \
+		-p trafic-cycliste-dev \
+		--profile all down -v --rmi all
 	docker system prune -f
 	docker volume prune -f

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap docker-install env setup git-setup dvc-setup repo-setup
+.PHONY: help bootstrap docker-install env setup git-setup dvc-setup
+.PHONY: repo-setup repo_setup
 .PHONY: env-compose env-local env-dagshub
-.PHONY: sync lock-check lint tests ci compose-config
+.PHONY: sync lock-check lint test tests ci compose-config
 .PHONY: build rebuild_full ops start stop logs
 .PHONY: mlops-ingest mlops-features mlops-models mlops-pipeline dvc-pipeline
 .PHONY: local-ingest local-features local-models local-pipeline mlflow-local
@@ -170,6 +171,8 @@ dvc-setup: env sync ## Configure local DVC credentials in .dvc/config.local
 
 repo-setup: git-setup dvc-setup ## Configure Git identity and local DVC credentials
 
+repo_setup: repo-setup ## Backward-compatible alias for repo-setup
+
 sync: ## Sync the local uv environment from uv.lock
 	@$(call log_test,sync)
 	$(UV) sync --locked --group test --group dev
@@ -181,6 +184,8 @@ lock-check: ## Check that uv.lock is consistent with pyproject.toml
 lint: ## Run Ruff checks
 	@$(call log_test,lint)
 	$(UV) run --locked --group test ruff check .
+
+test: tests ## Backward-compatible alias for tests
 
 tests: ## Run integration tests scope
 	@$(call log_test,integration-test)

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ SHELL := /bin/bash
 .PHONY: help bootstrap docker-install env setup git-setup dvc-setup
 .PHONY: repo-setup
 .PHONY: env-compose env-local env-dagshub
-.PHONY: sync lock-check lint tests ci compose-config
-.PHONY: build ops start stop logs
-.PHONY: mlops-ingest mlops-features mlops-models mlops-pipeline dvc-pipeline
+.PHONY: sync lock-check lint tests ci
+.PHONY: dvc-pipeline
 .PHONY: local-ingest local-features local-models local-pipeline mlflow-local
 .PHONY: sim_api_loop sim_api_down sim_api_req
 .PHONY: clean clean_env clean_full
@@ -133,7 +132,7 @@ env-dagshub: ## Print shell exports for DagsHub MLflow mode
 	printf 'unset AWS_SECRET_ACCESS_KEY\n'; \
 	printf 'unset AWS_DEFAULT_REGION\n'
 
-setup: env sync compose-config ## Prepare the local project after cloning
+setup: env sync dev-compose-config ## Prepare the local project after cloning
 
 git-setup: env ## Configure local Git identity from .env
 	@$(call log_test,git-setup)

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ SHELL := /bin/bash
 .PHONY: help bootstrap docker-install env setup git-setup dvc-setup
 .PHONY: repo-setup
 .PHONY: env-compose env-local env-dagshub
-.PHONY: sync lock-check lint tests ci
+.PHONY: sync lock-check lint tests checks
 .PHONY: dvc-pipeline
 .PHONY: local-ingest local-features local-models local-pipeline mlflow-local
-.PHONY: sim_api_loop sim_api_down sim_api_req
-.PHONY: clean clean_env clean_full
+.PHONY: sim-api-req
+.PHONY: clean-repo clean-env clean-docker
 
 UV ?= uv
 DOCKER_COMPOSE ?= docker compose
@@ -182,11 +182,13 @@ lint: ## Run Ruff checks
 	@$(call log_test,lint)
 	$(UV) run --locked --group test ruff check .
 
-tests: ## Run integration tests scope
+tests: ## Run unit and integration test scope
+	@$(call log_test,unit-test)
+	$(UV) run --locked --group test pytest -m "not integration" -v
 	@$(call log_test,integration-test)
 	$(UV) run --locked --group test pytest -m "integration" -v
 
-ci: lock-check lint tests ## Run local CI checks
+checks: lock-check lint tests ## Run local checks
 
 dvc-pipeline: env ## Run the full DVC pipeline
 	@$(call log_test,dvc-pipeline)
@@ -244,39 +246,8 @@ mlflow-local: env sync ## Start a host-side MLflow server for local experiments
 		--port $(MLFLOW_HOST_PORT) \
 		--backend-store-uri $(MLFLOW_BACKEND_STORE)
 
-sim_api_loop: ## Simulate 10 API stop/start cycles with a 5-second interval
-	@$(call log_test,sim_api_loop)
-	for i in {1..10}; do \
-		echo "[restart $$i] stopping api-dev..."; \
-		$(DOCKER_COMPOSE) \
-			--env-file $(ENV_FILE) \
-			-f docker/dev/docker-compose.yaml \
-			-p trafic-cycliste-dev stop api-dev; \
-		sleep 2; \
-		echo "[restart $$i] starting api-dev..."; \
-		$(DOCKER_COMPOSE) \
-			--env-file $(ENV_FILE) \
-			-f docker/dev/docker-compose.yaml \
-			-p trafic-cycliste-dev up -d api-dev; \
-		echo "[restart $$i] done, waiting 5s..."; \
-		sleep 5; \
-	done
-	@echo "==> Simulation finished"
-
-sim_api_down: ## Simulate a temporary API outage for 2 minutes
-	@$(call log_test,sim_api_down)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f docker/dev/docker-compose.yaml \
-		-p trafic-cycliste-dev stop api-dev
-	sleep 120
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f docker/dev/docker-compose.yaml \
-		-p trafic-cycliste-dev up -d api-dev
-
-sim_api_req: ## Simulate traffic on /predictions/{counter}
-	@$(call log_test,sim_api_req)
+sim-api-req: ## Simulate traffic on /predictions/{counter}
+	@$(call log_test,sim-api-req)
 	$(UV) run --locked --group test python tests/integration/test_load_api.py \
 		--url "$(URL)" \
 		--n $(N) \
@@ -287,23 +258,19 @@ sim_api_req: ## Simulate traffic on /predictions/{counter}
 		--offset $(OFFSET) \
 		$(if $(COUNTER_IDS),--counter-ids "$(COUNTER_IDS)",)
 
-clean: ## Remove local Python caches and test artifacts only
-	@$(call log_test,clean)
+clean-repo: ## Remove local Python caches and test artifacts only from the repository
+	@$(call log_test,clean-repo)
 	rm -rf .nox .pytest_cache .ruff_cache .coverage htmlcov build dist mlruns mlflow.db
 	find . -type d -name "__pycache__" -prune -exec rm -rf {} +
 	find . -type d -name "*.egg-info" -prune -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
-clean_env: ## Remove the uv-managed virtual environment
-	@$(call log_test,clean_env)
+clean-env: ## Remove the uv-managed virtual environment
+	@$(call log_test,clean-env)
 	rm -rf .venv
 
-clean_full: ## Remove development Docker artifacts, including images and volumes
-	@$(call log_test,clean_full)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f docker/dev/docker-compose.yaml \
-		-p trafic-cycliste-dev \
-		--profile all down -v --rmi all
+clean-docker: ## Remove Docker artifacts, including system, images and volumes unused
+	@$(call log_test,clean-docker)
+	docker image prune -f
 	docker system prune -f
 	docker volume prune -f

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 .PHONY: help bootstrap docker-install env setup git-setup dvc-setup
-.PHONY: repo-setup repo_setup
+.PHONY: repo-setup
 .PHONY: env-compose env-local env-dagshub
 .PHONY: sync lock-check lint test tests ci compose-config
-.PHONY: build rebuild_full ops start stop logs
+.PHONY: build ops start stop logs
 .PHONY: mlops-ingest mlops-features mlops-models mlops-pipeline dvc-pipeline
 .PHONY: local-ingest local-features local-models local-pipeline mlflow-local
 .PHONY: sim_api_loop sim_api_down sim_api_req
@@ -171,8 +171,6 @@ dvc-setup: env sync ## Configure local DVC credentials in .dvc/config.local
 
 repo-setup: git-setup dvc-setup ## Configure Git identity and local DVC credentials
 
-repo_setup: repo-setup ## Backward-compatible alias for repo-setup
-
 sync: ## Sync the local uv environment from uv.lock
 	@$(call log_test,sync)
 	$(UV) sync --locked --group test --group dev
@@ -192,28 +190,6 @@ tests: ## Run integration tests scope
 	$(UV) run --locked --group test pytest -m "integration" -v
 
 ci: lock-check lint tests ## Run local CI checks
-
-compose-config: dev-compose-config ## Validate the development Compose configuration
-
-build: dev-build ## Build development Docker images
-
-rebuild_full: dev-rebuild-full ## Rebuild development images and restart services
-
-ops: dev-ops ## Start development platform services
-
-start: dev-start ## Start development services for the selected profile
-
-stop: dev-stop ## Stop development services for the selected profile
-
-logs: dev-logs ## Follow development Docker Compose logs for SERVICE
-
-mlops-ingest: dev-mlops-ingest ## Run the development ML ingestion container once
-
-mlops-features: dev-mlops-features ## Run the development ML feature container once
-
-mlops-models: dev-mlops-models ## Run the development ML model container once
-
-mlops-pipeline: dev-mlops-pipeline ## Run the full development ML pipeline
 
 dvc-pipeline: env ## Run the full DVC pipeline
 	@$(call log_test,dvc-pipeline)

--- a/README.md
+++ b/README.md
@@ -178,22 +178,18 @@ make sync
 make lock-check
 make lint
 make tests
-make ci
+make checks
 ```
 
-`make tests` runs the current integration test scope. `make ci` chains the lock
-check, Ruff linting, and this test target.
+`make checks` runs all the checks : lock check, Ruff linting, and the tests target.
 
 Useful maintenance targets:
 
 ```bash
-make clean
-make clean_env
+make clean-repo
+make clean-env
+make clean-docker
 ```
-
-`make clean` removes local Python caches and test artifacts only. It does not
-remove Docker volumes. Use `make clean_env` only when you want to recreate the
-uv-managed virtual environment from scratch.
 
 ## MLOps setup
 

--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ This project implements a complete machine learning and MLOps architecture in th
 avr25-mle-trafic-cycliste/
 ├── LICENSE             <- MIT license
 ├── README.md           <- This top-level README for developers using this project
-├── Makefile            <- Local developer and Docker Compose operation targets
+├── Makefile            <- Repo setup plus dev/prod runtime target inclusion
 ├── .env.template       <- Template for local secrets and runtime variables
 ├── pyproject.toml      <- Python project, dependency groups, pytest, coverage, and Ruff configuration
 ├── uv.lock             <- uv lockfile for the local development environment
-├── data                <- Data shared with host (read/write)
-├── logs                <- Logs shared with host (read/write)
-├── models              <- Model artifacts shared with host (read/write)
+├── data                <- Development and DVC data workspace
+├── logs                <- Development runtime logs
+├── models              <- Development and DVC model artifacts
 ├── references          <- Data dictionaries, manuals, other explanatory material
 ├── src/                <- API and ML pipeline source code
-├── docker/             <- Container architecture, Airflow DAGs, configs, and scripts
+├── docker/             <- Dev/prod container architecture, Airflow assets, configs, and scripts
 ├── docs/               <- Architecture, operations, and dependency documentation
 └── tests/              <- Unit and integration tests
 ```
 
 Detailed path ownership, generated artifact expectations, DVC responsibilities,
-and the `docker/dev` versus future `docker/prod` split are documented in
+and the `docker/dev` versus `docker/prod` split are documented in
 [`docs/repository-structure.md`](docs/repository-structure.md).
 
 ## ⚙️ Installation
@@ -221,32 +221,48 @@ Docker Desktop can also be used during development on Windows, macOS, or Linux.
 
 ### 2. Docker Compose operation targets
 
-The project is assumed to be cloned when running operational commands. Prefer
-Makefile targets for project-level Docker operations:
+The project now has two explicit Compose runtime entrypoints:
+
+| Runtime | Compose file | Make targets | Goal |
+| ------- | ------------ | ------------ | ---- |
+| Development | `docker/dev/docker-compose.yaml` | `dev-*` plus legacy aliases | Debug visibility, root `data/logs/models`, current Airflow DockerOperator jobs. |
+| Local production-like | `docker/prod/docker-compose.yaml` | `prod-*` | Reduced host exposure, functional networks, non-root custom services, isolated runtime workspace. |
+
+The root `docker-compose.yaml` remains a compatibility entrypoint for existing
+manual commands, but new operational checks should prefer the explicit runtime
+targets.
+
+Development commands:
+
+```bash
+make dev-compose-config
+make dev-build
+make dev-ops
+make dev-ps
+make dev-logs SERVICE=api-dev
+```
+
+The existing aliases still target the development runtime:
 
 ```bash
 make compose-config
 make build
 make ops
+make logs SERVICE=api-dev
 ```
 
-`make ops` validates the Compose configuration and starts the default platform
-profile. The default profile is `ptf`, which combines MLflow, Airflow,
-monitoring, and API services.
-
-Targeted operations remain available when needed:
+Local production-like commands:
 
 ```bash
-make start PROFILE=api
-make stop PROFILE=api
-make logs SERVICE=api-dev
-make rebuild_full
-make clean_full
+make prod-compose-config
+make prod-build
+make prod-ops
+make prod-ps
+make prod-logs SERVICE=api-dev
 ```
 
-`make start` uses `docker compose up -d` so it works from a clean environment
-where containers have not been created yet. `make clean_full` is intentionally
-destructive: it removes Docker images, volumes, and networks.
+The default profile is `ptf`, which combines MLflow, Airflow, monitoring, and
+API services. Use `DEV_PROFILE=api` or `PROD_PROFILE=api` for targeted startup.
 
 Runtime host ports and local URLs are documented in
 [`docs/ports-and-services.md`](docs/ports-and-services.md). Runtime
@@ -255,9 +271,20 @@ service-to-service communication is documented in
 Runtime security boundaries and identities are documented in
 [`docs/runtime-security-boundaries.md`](docs/runtime-security-boundaries.md).
 Runtime image, healthcheck, and dependency policies are documented in
-[`docs/dependency-strategy.md`](docs/dependency-strategy.md).
+[`docs/dependency-strategy.md`](docs/dependency-strategy.md). Dev/prod Compose
+operation and workspace ownership are documented in
+[`docs/local-prod-runtime.md`](docs/local-prod-runtime.md).
 
-For one-off ML pipeline containers, use the dedicated targets:
+For one-off ML pipeline containers in the development runtime, use:
+
+```bash
+make dev-mlops-ingest
+make dev-mlops-features
+make dev-mlops-models
+make dev-mlops-pipeline
+```
+
+Legacy aliases remain available:
 
 ```bash
 make mlops-ingest
@@ -378,5 +405,5 @@ The CI environment uses uv dependency groups directly and runs Ruff before pytes
 
 - Rémy Canal – [@remy.canal](mailto:remy.canal@live.fr)  
 - Elias Djouadi – [@elias.djouadi](mailto:elias.djouadi@gmail.com)
-- Koladé Houessou – [@kolade.houessou](mailto:koladehouessou@gmail.com)
+- Koladé Houessou – [@koladehouessou@gmail.com](mailto:koladehouessou@gmail.com)
 - Sofia Bouizzoul - [@sofia.bouizzoul](mailto:sofia.bouizzoul@gmail.com)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ credentials to `.dvc/config.local`, which is ignored by `.dvc/.gitignore`.
 Use this convenience target when both steps are needed:
 
 ```bash
-make repo_setup
+make repo-setup
 ```
 
 The versioned DVC remote is defined in `.dvc/config`:
@@ -181,9 +181,9 @@ make test
 make ci
 ```
 
-`make ci` chains the lock check, Ruff linting, and unit tests while excluding
-integration tests. This mirrors the local validation path used by CI without
-requiring Docker services.
+`make test` is a compatibility alias for the current `tests` target, which runs
+the integration test scope. `make ci` chains the lock check, Ruff linting, and
+this test target.
 
 Useful maintenance targets:
 
@@ -225,30 +225,21 @@ The project now has two explicit Compose runtime entrypoints:
 
 | Runtime | Compose file | Make targets | Goal |
 | ------- | ------------ | ------------ | ---- |
-| Development | `docker/dev/docker-compose.yaml` | `dev-*` plus legacy aliases | Debug visibility, root `data/logs/models`, current Airflow DockerOperator jobs. |
+| Development | `docker/dev/docker-compose.yaml` | `dev-*` | Debug visibility, root `data/logs/models`, current Airflow DockerOperator jobs. |
 | Local production-like | `docker/prod/docker-compose.yaml` | `prod-*` | Reduced host exposure, functional networks, non-root custom services, isolated runtime workspace. |
 
 The root `docker-compose.yaml` remains a compatibility entrypoint for existing
-manual commands, but new operational checks should prefer the explicit runtime
-targets.
+manual `docker compose` commands from the repository root, but operational checks
+should prefer the explicit runtime targets.
 
 Development commands:
 
 ```bash
 make dev-compose-config
 make dev-build
-make dev-ops
+make dev-start
 make dev-ps
 make dev-logs SERVICE=api-dev
-```
-
-The existing aliases still target the development runtime:
-
-```bash
-make compose-config
-make build
-make ops
-make logs SERVICE=api-dev
 ```
 
 Local production-like commands:
@@ -256,7 +247,7 @@ Local production-like commands:
 ```bash
 make prod-compose-config
 make prod-build
-make prod-ops
+make prod-start
 make prod-ps
 make prod-logs SERVICE=api-dev
 ```
@@ -284,15 +275,6 @@ make dev-mlops-models
 make dev-mlops-pipeline
 ```
 
-Legacy aliases remain available:
-
-```bash
-make mlops-ingest
-make mlops-features
-make mlops-models
-make mlops-pipeline
-```
-
 ### 3. 📈 Experience tracker
 
 We use **MLflow** to record **metrics**, **params**, and training/prediction
@@ -317,12 +299,12 @@ eval "$(make --no-print-directory env-local)"
 eval "$(make --no-print-directory env-dagshub)"
 ```
 
-The MLOps container targets automatically use the Compose preset. Local debug
-targets automatically use the local backend preset.
+Compose runtime services read their values from `.env`. Host-side debug targets
+use explicit Makefile presets where needed.
 
 ```bash
-make ops
-make mlops-pipeline
+make dev-start
+make dev-mlops-pipeline
 make local-pipeline
 make mlflow-local
 ```

--- a/README.md
+++ b/README.md
@@ -177,13 +177,12 @@ Prefer these Makefile targets for day-to-day local validation:
 make sync
 make lock-check
 make lint
-make test
+make tests
 make ci
 ```
 
-`make test` is a compatibility alias for the current `tests` target, which runs
-the integration test scope. `make ci` chains the lock check, Ruff linting, and
-this test target.
+`make tests` runs the current integration test scope. `make ci` chains the lock
+check, Ruff linting, and this test target.
 
 Useful maintenance targets:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 # ========================
-# VOLUMES
+# LOCAL DEVELOPMENT RUNTIME
 # ========================
+# Compatibility entrypoint. The canonical development runtime now lives in
+# docker/dev/docker-compose.yaml and keeps the same services and behavior.
+
 volumes:
   mlflow-postgres-db:
     name: mlflow-postgres-db
@@ -17,9 +20,6 @@ volumes:
   monitoring-alertmanager-data:
     name: monitoring-alertmanager-data
 
-# ========================
-# NETWORK
-# ========================
 networks:
   airflow_net:
     name: airflow_net
@@ -31,9 +31,6 @@ networks:
     name: mlops_net
     driver: bridge
 
-# ========================
-# AIRFLOW COMMON
-# ========================
 x-airflow-common: &airflow-common
   image: ${AIRFLOW_IMAGE_NAME:?required}
   environment: &airflow-common-env
@@ -54,26 +51,26 @@ x-airflow-common: &airflow-common
     AIRFLOW__SMTP__SMTP_MAIL_FROM: "airflow@test.local"
     AIRFLOW__SMTP__SMTP_STARTTLS: "False"
     AIRFLOW__SMTP__SMTP_SSL: "False"
-  volumes:
-    - ./logs:/opt/airflow/logs
-    - ./data:/opt/airflow/data
-    - ./docker/dev/airflow/dags:/opt/airflow/dags
-    - ./docker/dev/airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on: &airflow-common-depends-on
     airflow-redis:
       condition: service_healthy
     airflow-postgres:
       condition: service_healthy
+  volumes:
+    - ./logs:/opt/airflow/logs
+    - ./data:/opt/airflow/data
+    - ./docker/dev/airflow/dags:/opt/airflow/dags
+    - ./docker/dev/airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
   networks:
     - airflow_net
     - mlops_net
   profiles: ["all", "airflow", "ptf"]
 
-# ========================
-# BUSINESS SERVICES
-# ========================
 services:
+  # ========================
+  # BUSINESS SERVICES
+  # ========================
   ml-ingest-dev:
     image: ml-ingest:dev
     build:
@@ -161,10 +158,6 @@ services:
       - --grid-iter
       - "${GRID_ITER}"
     restart: "no"
-    volumes:
-      - ./data:/app/data
-      - ./models:/app/models
-      - ./logs:/app/logs
     environment:
       MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
       MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
@@ -173,9 +166,13 @@ services:
       GIT_PYTHON_REFRESH: quiet
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
       DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ./data:/app/data
+      - ./models:/app/models
+      - ./logs:/app/logs
     networks:
-      - mlflow_net
       - airflow_net
+      - mlflow_net
       - mlops_net
     profiles: ["ml", "all"]
 
@@ -187,55 +184,63 @@ services:
     ports:
       - "${API_HOST_PORT:-10000}:10000"
     restart: unless-stopped
+    environment:
+      DATA_FINAL_ROOT: ${DATA_FINAL_ROOT}
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-    environment:
-      DATA_FINAL_ROOT: ${DATA_FINAL_ROOT}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10000/docs', timeout=5).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - airflow_net
       - mlops_net
     profiles: ["all", "api", "ptf"]
 
-# ========================
-# MLFLOW SERVICES
-# ========================
+  # ========================
+  # MLFLOW SERVICES
+  # ========================
   mlflow-postgres:
     image: ${MLFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${MLFLOW_POSTGRES_USER:?required}
       POSTGRES_PASSWORD: ${MLFLOW_POSTGRES_PASSWORD:?required}
       POSTGRES_DB: ${MLFLOW_POSTGRES_DB:?required}
+    volumes:
+      - mlflow-postgres-db:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${MLFLOW_POSTGRES_USER:?required}"]
       interval: 10s
       timeout: 5s
       retries: 5
-    volumes:
-      - mlflow-postgres-db:/var/lib/postgresql/data
-    restart: unless-stopped
     networks:
       - mlflow_net
     profiles: ["all", "mlflow", "ptf"]
 
   mlflow-minio:
     image: ${MLFLOW_MINIO_IMAGE:?required}
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:?required}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:?required}
-    command: server /data --console-address ":9001"
-    volumes:
-      - mlflow-minio-data:/data
     ports:
       - "${MINIO_API_HOST_PORT:-13000}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-13002}:9001"
+    volumes:
+      - mlflow-minio-data:/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     networks:
       - mlflow_net
       - mlops_net
@@ -259,6 +264,7 @@ services:
 
   mlflow-server:
     image: ${MLFLOW_IMAGE:?required}
+    restart: unless-stopped
     depends_on:
       mlflow-postgres:
         condition: service_healthy
@@ -266,6 +272,15 @@ services:
         condition: service_healthy
       mlflow-mc-init:
         condition: service_completed_successfully
+    command:
+      - mlflow
+      - server
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5000"
+      - --allowed-hosts
+      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
     environment:
       MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
       MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
@@ -284,26 +299,17 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    command:
-      - mlflow
-      - server
-      - --host
-      - 0.0.0.0
-      - --port
-      - "5000"
-      - --allowed-hosts
-      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
-    restart: unless-stopped
     networks:
       - mlflow_net
       - mlops_net
     profiles: ["all", "mlflow", "ptf"]
 
-# ========================
-# AIRFLOW SERVICES
-# ========================
+  # ========================
+  # AIRFLOW SERVICES
+  # ========================
   airflow-postgres:
     image: ${AIRFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${AIRFLOW_POSTGRES_USER:?required}
       POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:?required}
@@ -315,32 +321,31 @@ services:
       interval: 10s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     networks:
       - airflow_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-redis:
     image: ${AIRFLOW_REDIS_IMAGE:?required}
+    restart: unless-stopped
+    volumes:
+      - airflow-redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    volumes:
-      - airflow-redis-data:/data
-    restart: unless-stopped
     networks:
       - airflow_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-init:
     <<: *airflow-common
+    restart: "no"
     environment:
       <<: *airflow-common-env
     command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
-    restart: "no"
     volumes:
       - ./docker/dev/airflow/config/:/opt/airflow/config/
       - ./docker/dev/airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
@@ -348,6 +353,7 @@ services:
 
   airflow-api-server:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -361,64 +367,57 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-scheduler:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
     command: ["scheduler"]
     healthcheck:
-      test: ["CMD-SHELL", 'airflow jobs check --job-type SchedulerJob --hostname "$${HOSTNAME}"']
+      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $${HOSTNAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-dag-processor:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
     command: ["dag-processor"]
     healthcheck:
-      test: ["CMD-SHELL", 'airflow jobs check --job-type DagProcessorJob --hostname "$${HOSTNAME}"']
+      test: ["CMD-SHELL", "airflow jobs check --job-type DagProcessorJob --hostname $${HOSTNAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-worker:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
-    environment:
-      <<: *airflow-common-env
-      DOCKER_HOST: unix:///var/run/docker.sock
-      AIRFLOW_UID: ${AIRFLOW_UID:-50000}
-      AIRFLOW_GID: ${AIRFLOW_GID:-0}
-    user: "0:0"
+    command: ["celery", "worker"]
     entrypoint: ["/opt/airflow/scripts/airflow-entrypoint.sh"]
+    user: "0:0"
     group_add:
       - ${AIRFLOW_GID:-0}
-    command: ["celery", "worker"]
-    healthcheck:
-      test: ["CMD-SHELL", 'runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}" || runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"']
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
-    restart: unless-stopped
+    environment:
+      <<: *airflow-common-env
+      AIRFLOW_GID: ${AIRFLOW_GID:-0}
+      AIRFLOW_UID: ${AIRFLOW_UID:-50000}
+      DOCKER_HOST: unix:///var/run/docker.sock
     volumes:
       - ./logs:/opt/airflow/logs
       - ./data:/opt/airflow/data
@@ -426,6 +425,12 @@ services:
       - ./docker/dev/airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker/dev/airflow/scripts/airflow-entrypoint.sh:/opt/airflow/scripts/airflow-entrypoint.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - airflow_net
       - mlops_net
@@ -433,22 +438,23 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
     command: ["triggerer"]
     healthcheck:
-      test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
+      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $${HOSTNAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-flower:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -456,7 +462,6 @@ services:
     command: ["celery", "flower"]
     ports:
       - "${AIRFLOW_FLOWER_HOST_PORT:-12555}:5555"
-    restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
       interval: 10s
@@ -467,17 +472,17 @@ services:
       - airflow_net
     profiles: ["all", "airflow", "ptf", "flower"]
 
-# ========================
-# MONITORING SERVICES
-# ========================
+  # ========================
+  # MONITORING SERVICES
+  # ========================
   monitoring-prometheus:
     image: ${PROMETHEUS_IMAGE:?required}
     restart: unless-stopped
-    ports:
-      - "${PROMETHEUS_HOST_PORT:-14090}:9090"
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=15d
+    ports:
+      - "${PROMETHEUS_HOST_PORT:-14090}:9090"
     volumes:
       - ./docker/dev/prometheus:/etc/prometheus:ro
       - monitoring-prometheus-data:/prometheus
@@ -494,12 +499,14 @@ services:
   monitoring-grafana:
     image: ${GRAFANA_IMAGE:?required}
     restart: unless-stopped
-    ports:
-      - "${GRAFANA_HOST_PORT:-14300}:3000"
+    depends_on:
+      - monitoring-prometheus
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
     volumes:
       - monitoring-grafana-data:/var/lib/grafana
       - ./docker/dev/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -510,8 +517,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    depends_on:
-      - monitoring-prometheus
     networks:
       - mlops_net
     profiles: ["monitoring", "all", "ptf"]
@@ -539,9 +544,9 @@ services:
 
   monitoring-pushgateway:
     image: ${PUSHGATEWAY_IMAGE:?required}
+    restart: unless-stopped
     ports:
       - "${PUSHGATEWAY_HOST_PORT:-14091}:9091"
-    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/-/ready"]
       interval: 10s
@@ -554,12 +559,12 @@ services:
 
   monitoring-alertmanager:
     image: ${ALERTMANAGER_IMAGE:?required}
+    restart: unless-stopped
+    ports:
+      - "${ALERTMANAGER_HOST_PORT:-14093}:9093"
     volumes:
       - ./docker/dev/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - monitoring-alertmanager-data:/alertmanager
-    ports:
-      - "${ALERTMANAGER_HOST_PORT:-14093}:9093"
-    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
       interval: 10s
@@ -572,10 +577,10 @@ services:
 
   monitoring-mailhog:
     image: ${MAILHOG_IMAGE:?required}
+    restart: unless-stopped
     ports:
       - "${MAILHOG_SMTP_HOST_PORT:-15025}:1025"
       - "${MAILHOG_UI_HOST_PORT:-15080}:8025"
-    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
       interval: 10s

--- a/docker/dev/Makefile
+++ b/docker/dev/Makefile
@@ -3,15 +3,16 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 .PHONY: dev-help dev-compose-config dev-build
-.PHONY: dev-start dev-stop dev-down dev-ps dev-logs
+.PHONY: dev-start dev-stop dev-down dev-ps dev-logs dev-clean
 .PHONY: dev-mlops-ingest dev-mlops-features dev-mlops-models
 .PHONY: dev-mlops-pipeline
+.PHONY: dev-sim-api-loop dev-sim-api-down 
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
 DEV_COMPOSE_FILE ?= docker/dev/docker-compose.yaml
 DEV_PROFILE ?= ptf
-DEV_PROJECT_NAME ?= trafic-cycliste-dev
+DEV_PROJECT_NAME ?= bike-traffic-dev
 SERVICE ?= api-dev
 
 dev_log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
@@ -61,6 +62,10 @@ dev-logs: ## Follow logs for SERVICE in the development runtime
 	@$(call dev_log_target,dev-logs SERVICE=$(SERVICE))
 	$(dev_compose) logs -f -t $(SERVICE)
 
+dev-clean: ## Remove Docker artifacts, including images and volumes
+	@$(call log_test,dev-clean)
+	$(prod_compose) --profile all down -v --rmi all
+
 dev-mlops-ingest: ## Run the development ML ingestion container once
 	@$(call dev_log_target,dev-mlops-ingest)
 	@$(dev_check_env)
@@ -77,3 +82,22 @@ dev-mlops-models: ## Run the development ML model container once
 	$(dev_compose) --profile ml up ml-models-dev
 
 dev-mlops-pipeline: dev-mlops-ingest dev-mlops-features dev-mlops-models ## Run the full development ML pipeline
+
+dev-sim-api-loop: ## Simulate 10 API stop/start cycles with a 5-second interval
+	@$(call log_test,dev-sim-api-loop)
+	for i in {1..10}; do \
+		echo "[restart $$i] stopping api-dev..."; \
+		$(dev_compose) stop api-dev; \
+		sleep 2; \
+		echo "[restart $$i] starting api-dev..."; \
+		$(dev_compose) up -d api-dev; \
+		echo "[restart $$i] done, waiting 5s..."; \
+		sleep 5; \
+	done
+	@echo "==> Simulation finished"
+
+dev-sim-api-down: ## Simulate a temporary API outage for 2 minutes
+	@$(call log_test,dev-sim-api-down)
+	$(dev_compose) stop api-dev
+	sleep 120
+	$(dev_compose) up -d api-dev

--- a/docker/dev/Makefile
+++ b/docker/dev/Makefile
@@ -2,8 +2,8 @@ SHELL := /bin/bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: dev-help dev-compose-config dev-build dev-rebuild-full
-.PHONY: dev-ops dev-start dev-stop dev-down dev-ps dev-logs
+.PHONY: dev-help dev-compose-config dev-build
+.PHONY: dev-start dev-stop dev-down dev-ps dev-logs
 .PHONY: dev-mlops-ingest dev-mlops-features dev-mlops-models
 .PHONY: dev-mlops-pipeline
 
@@ -39,15 +39,6 @@ dev-build: ## Build local development Docker images
 	@$(call dev_log_target,dev-build)
 	@$(dev_check_env)
 	$(dev_compose) --profile all build
-
-dev-rebuild-full: dev-build ## Rebuild and restart development platform services
-	@$(call dev_log_target,dev-rebuild-full)
-	$(dev_compose) --profile all down
-	$(dev_compose) --profile ptf up -d
-
-dev-ops: dev-compose-config ## Start local development platform services
-	@$(call dev_log_target,dev-ops DEV_PROFILE=$(DEV_PROFILE))
-	$(dev_compose) --profile $(DEV_PROFILE) up -d
 
 dev-start: ## Start development services for the selected profile
 	@$(call dev_log_target,dev-start DEV_PROFILE=$(DEV_PROFILE))

--- a/docker/dev/Makefile
+++ b/docker/dev/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 .PHONY: dev-start dev-stop dev-down dev-ps dev-logs dev-clean
 .PHONY: dev-mlops-ingest dev-mlops-features dev-mlops-models
 .PHONY: dev-mlops-pipeline
-.PHONY: dev-sim-api-loop dev-sim-api-down 
+.PHONY: dev-sim-api-loop dev-sim-api-down
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
@@ -52,7 +52,7 @@ dev-stop: ## Stop development services for the selected profile
 
 dev-down: ## Remove development containers and networks
 	@$(call dev_log_target,dev-down)
-	$(dev_compose) --profile all down
+	$(dev_compose) --profile all down --remove-orphans
 
 dev-ps: ## Show development service status
 	@$(call dev_log_target,dev-ps)
@@ -62,9 +62,10 @@ dev-logs: ## Follow logs for SERVICE in the development runtime
 	@$(call dev_log_target,dev-logs SERVICE=$(SERVICE))
 	$(dev_compose) logs -f -t $(SERVICE)
 
-dev-clean: ## Remove Docker artifacts, including images and volumes
-	@$(call log_test,dev-clean)
-	$(prod_compose) --profile all down -v --rmi all
+dev-clean: ## Remove development containers, networks, and volumes
+	@$(call dev_log_target,dev-clean)
+	@$(dev_check_env)
+	$(dev_compose) --profile all down -v --remove-orphans
 
 dev-mlops-ingest: ## Run the development ML ingestion container once
 	@$(call dev_log_target,dev-mlops-ingest)
@@ -84,7 +85,7 @@ dev-mlops-models: ## Run the development ML model container once
 dev-mlops-pipeline: dev-mlops-ingest dev-mlops-features dev-mlops-models ## Run the full development ML pipeline
 
 dev-sim-api-loop: ## Simulate 10 API stop/start cycles with a 5-second interval
-	@$(call log_test,dev-sim-api-loop)
+	@$(call dev_log_target,dev-sim-api-loop)
 	for i in {1..10}; do \
 		echo "[restart $$i] stopping api-dev..."; \
 		$(dev_compose) stop api-dev; \
@@ -97,7 +98,7 @@ dev-sim-api-loop: ## Simulate 10 API stop/start cycles with a 5-second interval
 	@echo "==> Simulation finished"
 
 dev-sim-api-down: ## Simulate a temporary API outage for 2 minutes
-	@$(call log_test,dev-sim-api-down)
+	@$(call dev_log_target,dev-sim-api-down)
 	$(dev_compose) stop api-dev
 	sleep 120
 	$(dev_compose) up -d api-dev

--- a/docker/dev/Makefile
+++ b/docker/dev/Makefile
@@ -1,0 +1,88 @@
+SHELL := /bin/bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+
+.PHONY: dev-help dev-compose-config dev-build dev-rebuild-full
+.PHONY: dev-ops dev-start dev-stop dev-down dev-ps dev-logs
+.PHONY: dev-mlops-ingest dev-mlops-features dev-mlops-models
+.PHONY: dev-mlops-pipeline
+
+DOCKER_COMPOSE ?= docker compose
+ENV_FILE ?= .env
+DEV_COMPOSE_FILE ?= docker/dev/docker-compose.yaml
+DEV_PROFILE ?= ptf
+DEV_PROJECT_NAME ?= trafic-cycliste-dev
+SERVICE ?= api-dev
+
+dev_log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
+dev_check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
+
+dev_compose = $(DOCKER_COMPOSE) \
+	--env-file $(ENV_FILE) \
+	-f $(DEV_COMPOSE_FILE) \
+	-p $(DEV_PROJECT_NAME)
+
+dev-help: ## Display local development runtime targets
+	@awk ' \
+		BEGIN {FS=":.*##"; printf "\nLocal development targets:\n\n"} \
+		/^[a-zA-Z0-9_.-]+:.*##/ { \
+			printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 \
+		} \
+	' $(MAKEFILE_LIST)
+
+dev-compose-config: ## Validate the local development Compose config
+	@$(call dev_log_target,dev-compose-config)
+	@$(dev_check_env)
+	$(dev_compose) --profile all config >/dev/null
+
+dev-build: ## Build local development Docker images
+	@$(call dev_log_target,dev-build)
+	@$(dev_check_env)
+	$(dev_compose) --profile all build
+
+dev-rebuild-full: dev-build ## Rebuild and restart development platform services
+	@$(call dev_log_target,dev-rebuild-full)
+	$(dev_compose) --profile all down
+	$(dev_compose) --profile ptf up -d
+
+dev-ops: dev-compose-config ## Start local development platform services
+	@$(call dev_log_target,dev-ops DEV_PROFILE=$(DEV_PROFILE))
+	$(dev_compose) --profile $(DEV_PROFILE) up -d
+
+dev-start: ## Start development services for the selected profile
+	@$(call dev_log_target,dev-start DEV_PROFILE=$(DEV_PROFILE))
+	@$(dev_check_env)
+	$(dev_compose) --profile $(DEV_PROFILE) up -d
+
+dev-stop: ## Stop development services for the selected profile
+	@$(call dev_log_target,dev-stop DEV_PROFILE=$(DEV_PROFILE))
+	$(dev_compose) --profile $(DEV_PROFILE) stop
+
+dev-down: ## Remove development containers and networks
+	@$(call dev_log_target,dev-down)
+	$(dev_compose) --profile all down
+
+dev-ps: ## Show development service status
+	@$(call dev_log_target,dev-ps)
+	$(dev_compose) --profile all ps
+
+dev-logs: ## Follow logs for SERVICE in the development runtime
+	@$(call dev_log_target,dev-logs SERVICE=$(SERVICE))
+	$(dev_compose) logs -f -t $(SERVICE)
+
+dev-mlops-ingest: ## Run the development ML ingestion container once
+	@$(call dev_log_target,dev-mlops-ingest)
+	@$(dev_check_env)
+	$(dev_compose) --profile ml up ml-ingest-dev
+
+dev-mlops-features: ## Run the development ML feature container once
+	@$(call dev_log_target,dev-mlops-features)
+	@$(dev_check_env)
+	$(dev_compose) --profile ml up ml-features-dev
+
+dev-mlops-models: ## Run the development ML model container once
+	@$(call dev_log_target,dev-mlops-models)
+	@$(dev_check_env)
+	$(dev_compose) --profile ml up ml-models-dev
+
+dev-mlops-pipeline: dev-mlops-ingest dev-mlops-features dev-mlops-models ## Run the full development ML pipeline

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,0 +1,54 @@
+# Local development Docker Compose runtime
+
+This folder contains the canonical local development runtime.
+
+It mirrors the `docker/prod` folder structure so contributors can compare the
+development and local production-like runtimes without reading unrelated project
+setup targets.
+
+The root `docker-compose.yaml` is kept as a compatibility entrypoint for now.
+New operational targets should prefer `docker/dev/docker-compose.yaml` through
+`docker/dev/Makefile` or the root Makefile aliases.
+
+## Validate
+
+```bash
+make dev-compose-config
+```
+
+Equivalent explicit command:
+
+```bash
+make -f docker/dev/Makefile dev-compose-config
+```
+
+## Start
+
+```bash
+make dev-ops
+```
+
+The default development profile is `ptf`. Override it when needed:
+
+```bash
+make dev-ops DEV_PROFILE=api
+```
+
+## Stop
+
+```bash
+make dev-stop
+make dev-down
+```
+
+## Design constraints
+
+- Keep broad host visibility for local debugging.
+- Keep current DockerOperator-based Airflow ML execution available.
+- Keep `data`, `logs`, and `models` as root-level local/DVC workspaces.
+- Keep development UIs and debug ports available.
+- Keep comments, sections, and property ordering close to `docker/prod` so diffs
+  remain easy to review.
+
+See `docs/local-prod-runtime.md` for the production-like counterpart and the
+expected divergence points.

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -6,9 +6,9 @@ It mirrors the `docker/prod` folder structure so contributors can compare the
 development and local production-like runtimes without reading unrelated project
 setup targets.
 
-The root `docker-compose.yaml` is kept as a compatibility entrypoint for now.
-New operational targets should prefer `docker/dev/docker-compose.yaml` through
-`docker/dev/Makefile` or the root Makefile aliases.
+The root `docker-compose.yaml` is kept as a compatibility entrypoint for manual
+Compose commands from the repository root. New operational targets should prefer
+`docker/dev/docker-compose.yaml` through `docker/dev/Makefile`.
 
 ## Validate
 
@@ -25,13 +25,13 @@ make -f docker/dev/Makefile dev-compose-config
 ## Start
 
 ```bash
-make dev-ops
+make dev-start
 ```
 
 The default development profile is `ptf`. Override it when needed:
 
 ```bash
-make dev-ops DEV_PROFILE=api
+make dev-start DEV_PROFILE=api
 ```
 
 ## Stop

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -16,12 +16,6 @@ Compose commands from the repository root. New operational targets should prefer
 make dev-compose-config
 ```
 
-Equivalent explicit command:
-
-```bash
-make -f docker/dev/Makefile dev-compose-config
-```
-
 ## Start
 
 ```bash

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -1,0 +1,592 @@
+# ========================
+# LOCAL DEVELOPMENT RUNTIME
+# ========================
+# This Compose entrypoint is the canonical development runtime. The root
+# docker-compose.yaml is kept as a compatibility entrypoint for existing habits.
+
+volumes:
+  mlflow-postgres-db:
+    name: mlflow-postgres-db
+  mlflow-minio-data:
+    name: mlflow-minio-data
+  airflow-postgres-db:
+    name: airflow-postgres-db
+  airflow-redis-data:
+    name: airflow-redis-data
+  monitoring-prometheus-data:
+    name: monitoring-prometheus-data
+  monitoring-grafana-data:
+    name: monitoring-grafana-data
+  monitoring-alertmanager-data:
+    name: monitoring-alertmanager-data
+
+networks:
+  airflow_net:
+    name: airflow_net
+    driver: bridge
+  mlflow_net:
+    name: mlflow_net
+    driver: bridge
+  mlops_net:
+    name: mlops_net
+    driver: bridge
+
+x-airflow-common: &airflow-common
+  image: ${AIRFLOW_IMAGE_NAME:?required}
+  environment: &airflow-common-env
+    AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${AIRFLOW_POSTGRES_USER:?required}:${AIRFLOW_POSTGRES_PASSWORD:?required}@airflow-postgres/${AIRFLOW_POSTGRES_DB:?required}
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${AIRFLOW_POSTGRES_USER:?required}:${AIRFLOW_POSTGRES_PASSWORD:?required}@airflow-postgres/${AIRFLOW_POSTGRES_DB:?required}
+    AIRFLOW__CELERY__BROKER_URL: redis://:@airflow-redis:6379/0
+    AIRFLOW__CORE__FERNET_KEY: "${AIRFLOW_FERNET_KEY:?required}"
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__CORE__AUTH_MANAGER: airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager
+    AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-api-server:8080/execution/
+    AIRFLOW__API__BASE_URL: http://airflow-api-server:8080
+    AIRFLOW__API_AUTH__JWT_SECRET: "${AIRFLOW_API_AUTH_JWT_SECRET:?required}"
+    AIRFLOW__SIMPLE_AUTH_MANAGER__USERS: "admin:admin"
+    AIRFLOW__SMTP__SMTP_HOST: "monitoring-mailhog"
+    AIRFLOW__SMTP__SMTP_PORT: 1025
+    AIRFLOW__SMTP__SMTP_MAIL_FROM: "airflow@test.local"
+    AIRFLOW__SMTP__SMTP_STARTTLS: "False"
+    AIRFLOW__SMTP__SMTP_SSL: "False"
+  user: "${AIRFLOW_UID:-50000}:0"
+  depends_on: &airflow-common-depends-on
+    airflow-redis:
+      condition: service_healthy
+    airflow-postgres:
+      condition: service_healthy
+  volumes:
+    - ../../logs:/opt/airflow/logs
+    - ../../data:/opt/airflow/data
+    - ./airflow/dags:/opt/airflow/dags
+    - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
+  networks:
+    - airflow_net
+    - mlops_net
+  profiles: ["all", "airflow", "ptf"]
+
+services:
+  # ========================
+  # BUSINESS SERVICES
+  # ========================
+  ml-ingest-dev:
+    image: ml-ingest:dev
+    build:
+      context: ../..
+      dockerfile: ./docker/dev/ml/ingest/Dockerfile
+    command:
+      - --raw-path
+      - /app/data/raw/${RAW_FILE_NAME}
+      - --site
+      - ${SITE}
+      - --orientation
+      - ${ORIENTATION}
+      - --range-start
+      - "${RANGE_START}"
+      - --range-end
+      - "${RANGE_END}"
+      - --timestamp-col
+      - date_et_heure_de_comptage
+      - --sub-dir
+      - ${SUB_DIR}
+      - --interim-name
+      - ${INTERIM_NAME}
+    restart: "no"
+    environment:
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../logs:/app/logs
+    networks:
+      - airflow_net
+      - mlops_net
+    profiles: ["ml", "all"]
+
+  ml-features-dev:
+    image: ml-features:dev
+    build:
+      context: ../..
+      dockerfile: ./docker/dev/ml/features/Dockerfile
+    command:
+      - --interim-path
+      - /app/data/interim/${SUB_DIR}/${INTERIM_NAME}
+      - --sub-dir
+      - ${SUB_DIR}
+      - --processed-name
+      - ${PROCESSED_NAME}
+      - --timestamp-col
+      - date_et_heure_de_comptage
+    restart: "no"
+    environment:
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../logs:/app/logs
+    networks:
+      - airflow_net
+      - mlops_net
+    profiles: ["ml", "all"]
+
+  ml-models-dev:
+    image: ml-models:dev
+    build:
+      context: ../..
+      dockerfile: ./docker/dev/ml/models/Dockerfile
+    command:
+      - --processed-path
+      - /app/data/processed/${SUB_DIR}/${PROCESSED_NAME}
+      - --sub-dir
+      - ${SUB_DIR}
+      - --target-col
+      - comptage_horaire
+      - --ts-col-utc
+      - date_et_heure_de_comptage_utc
+      - --ts-col-local
+      - date_et_heure_de_comptage_local
+      - --ar
+      - "${AR}"
+      - --mm
+      - "${MM}"
+      - --roll
+      - "${ROLL}"
+      - --test-ratio
+      - "${TEST_RATIO}"
+      - --grid-iter
+      - "${GRID_ITER}"
+    restart: "no"
+    environment:
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
+      MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      GIT_PYTHON_REFRESH: quiet
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../models:/app/models
+      - ../../logs:/app/logs
+    networks:
+      - airflow_net
+      - mlflow_net
+      - mlops_net
+    profiles: ["ml", "all"]
+
+  api-dev:
+    image: api:dev
+    build:
+      context: ../..
+      dockerfile: ./docker/dev/api/Dockerfile
+    ports:
+      - "${API_HOST_PORT:-10000}:10000"
+    restart: unless-stopped
+    environment:
+      DATA_FINAL_ROOT: ${DATA_FINAL_ROOT}
+    volumes:
+      - ../../data:/app/data
+      - ../../logs:/app/logs
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10000/docs', timeout=5).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - airflow_net
+      - mlops_net
+    profiles: ["all", "api", "ptf"]
+
+  # ========================
+  # MLFLOW SERVICES
+  # ========================
+  mlflow-postgres:
+    image: ${MLFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${MLFLOW_POSTGRES_USER:?required}
+      POSTGRES_PASSWORD: ${MLFLOW_POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${MLFLOW_POSTGRES_DB:?required}
+    volumes:
+      - mlflow-postgres-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${MLFLOW_POSTGRES_USER:?required}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mlflow_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-minio:
+    image: ${MLFLOW_MINIO_IMAGE:?required}
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:?required}
+      MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:?required}
+    ports:
+      - "${MINIO_API_HOST_PORT:-13000}:9000"
+      - "${MINIO_CONSOLE_HOST_PORT:-13002}:9001"
+    volumes:
+      - mlflow-minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlflow_net
+      - mlops_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-mc-init:
+    image: ${MLFLOW_MINIO_MC_IMAGE:?required}
+    depends_on:
+      mlflow-minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set minio http://mlflow-minio:9000 ${AWS_ACCESS_KEY_ID:?required} ${AWS_SECRET_ACCESS_KEY:?required} &&
+      mc mb -p minio/mlflow || true &&
+      mc anonymous set download minio/mlflow || true &&
+      touch /tmp/ok && sleep 1
+      "
+    networks:
+      - mlflow_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-server:
+    image: ${MLFLOW_IMAGE:?required}
+    restart: unless-stopped
+    depends_on:
+      mlflow-postgres:
+        condition: service_healthy
+      mlflow-minio:
+        condition: service_healthy
+      mlflow-mc-init:
+        condition: service_completed_successfully
+    command:
+      - mlflow
+      - server
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5000"
+      - --allowed-hosts
+      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
+    environment:
+      MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
+      MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?required}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?required}
+      AWS_DEFAULT_REGION: us-east-1
+      GIT_PYTHON_REFRESH: quiet
+      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
+    ports:
+      - "${MLFLOW_HOST_PORT:-13001}:5000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health', timeout=5).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlflow_net
+      - mlops_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  # ========================
+  # AIRFLOW SERVICES
+  # ========================
+  airflow-postgres:
+    image: ${AIRFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${AIRFLOW_POSTGRES_USER:?required}
+      POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${AIRFLOW_POSTGRES_DB:?required}
+    volumes:
+      - airflow-postgres-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${AIRFLOW_POSTGRES_USER:?required}"]
+      interval: 10s
+      retries: 5
+      start_period: 15s
+    networks:
+      - airflow_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-redis:
+    image: ${AIRFLOW_REDIS_IMAGE:?required}
+    restart: unless-stopped
+    volumes:
+      - airflow-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - airflow_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-init:
+    <<: *airflow-common
+    restart: "no"
+    environment:
+      <<: *airflow-common-env
+    command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
+    volumes:
+      - ./airflow/config/:/opt/airflow/config/
+      - ./airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-api-server:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["api-server"]
+    ports:
+      - "${AIRFLOW_HOST_PORT:-12080}:8080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-scheduler:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["scheduler"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-dag-processor:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["dag-processor"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type DagProcessorJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-worker:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["celery", "worker"]
+    entrypoint: ["/opt/airflow/scripts/airflow-entrypoint.sh"]
+    user: "0:0"
+    group_add:
+      - ${AIRFLOW_GID:-0}
+    environment:
+      <<: *airflow-common-env
+      AIRFLOW_GID: ${AIRFLOW_GID:-0}
+      AIRFLOW_UID: ${AIRFLOW_UID:-50000}
+      DOCKER_HOST: unix:///var/run/docker.sock
+    volumes:
+      - ../../logs:/opt/airflow/logs
+      - ../../data:/opt/airflow/data
+      - ./airflow/dags:/opt/airflow/dags
+      - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./airflow/scripts/airflow-entrypoint.sh:/opt/airflow/scripts/airflow-entrypoint.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || runuser --preserve-environment --user airflow -- /home/airflow/.local/bin/celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - airflow_net
+      - mlops_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-triggerer:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["triggerer"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-flower:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["celery", "flower"]
+    ports:
+      - "${AIRFLOW_FLOWER_HOST_PORT:-12555}:5555"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - airflow_net
+    profiles: ["all", "airflow", "ptf", "flower"]
+
+  # ========================
+  # MONITORING SERVICES
+  # ========================
+  monitoring-prometheus:
+    image: ${PROMETHEUS_IMAGE:?required}
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    ports:
+      - "${PROMETHEUS_HOST_PORT:-14090}:9090"
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - monitoring-prometheus-data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-grafana:
+    image: ${GRAFANA_IMAGE:?required}
+    restart: unless-stopped
+    depends_on:
+      - monitoring-prometheus
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
+    volumes:
+      - monitoring-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-cadvisor:
+    image: ${CADVISOR_IMAGE:?required}
+    restart: unless-stopped
+    privileged: true
+    ports:
+      - "${CADVISOR_HOST_PORT:-14200}:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-pushgateway:
+    image: ${PUSHGATEWAY_IMAGE:?required}
+    restart: unless-stopped
+    ports:
+      - "${PUSHGATEWAY_HOST_PORT:-14091}:9091"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-alertmanager:
+    image: ${ALERTMANAGER_IMAGE:?required}
+    restart: unless-stopped
+    ports:
+      - "${ALERTMANAGER_HOST_PORT:-14093}:9093"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - monitoring-alertmanager-data:/alertmanager
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["all", "monitoring", "ptf"]
+
+  monitoring-mailhog:
+    image: ${MAILHOG_IMAGE:?required}
+    restart: unless-stopped
+    ports:
+      - "${MAILHOG_SMTP_HOST_PORT:-15025}:1025"
+      - "${MAILHOG_UI_HOST_PORT:-15080}:8025"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - mlops_net
+    profiles: ["all", "monitoring", "ptf"]

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 .PHONY: prod-help prod-prepare-runtime prod-compose-config prod-build
-.PHONY: prod-ops prod-stop prod-down prod-ps prod-logs
+.PHONY: prod-start prod-stop prod-down prod-ps prod-logs
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
@@ -50,7 +50,7 @@ prod-build: prod-prepare-runtime ## Build local production-like Docker images
 	@$(prod_check_env)
 	$(prod_compose) --profile all build
 
-prod-ops: prod-compose-config ## Start local production-like platform services
+prod-start: prod-compose-config ## Start local production-like platform services
 	@$(call prod_log_target,prod-ops PROD_PROFILE=$(PROD_PROFILE))
 	$(prod_compose) --profile $(PROD_PROFILE) up -d
 

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -1,0 +1,81 @@
+SHELL := /bin/bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+.PHONY: help prod-compose-config prod-build prod-ops prod-stop prod-down
+.PHONY: prod-ps prod-logs
+
+DOCKER_COMPOSE ?= docker compose
+ENV_FILE ?= .env
+PROD_COMPOSE_FILE ?= docker/prod/docker-compose.yaml
+PROD_PROFILE ?= ptf
+SERVICE ?= api-dev
+
+log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
+check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
+
+help: ## Display local production-like runtime targets
+	@awk ' \
+		BEGIN {FS=":.*##"; printf "\nLocal production-like targets:\n\n"} \
+		/^[a-zA-Z0-9_.-]+:.*##/ { \
+			printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 \
+		} \
+	' $(MAKEFILE_LIST)
+
+prod-compose-config: ## Validate the local production-like Compose config
+	@$(call log_target,prod-compose-config)
+	@$(check_env)
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile all \
+		config >/dev/null
+
+prod-build: ## Build local production-like Docker images
+	@$(call log_target,prod-build)
+	@$(check_env)
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile all \
+		build
+
+prod-ops: prod-compose-config ## Start local production-like platform services
+	@$(call log_target,prod-ops PROD_PROFILE=$(PROD_PROFILE))
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile $(PROD_PROFILE) \
+		up -d
+
+prod-stop: ## Stop local production-like services for the selected profile
+	@$(call log_target,prod-stop PROD_PROFILE=$(PROD_PROFILE))
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile $(PROD_PROFILE) \
+		stop
+
+prod-down: ## Remove local production-like containers and networks
+	@$(call log_target,prod-down)
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile all \
+		down
+
+prod-ps: ## Show local production-like service status
+	@$(call log_target,prod-ps)
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		--profile all \
+		ps
+
+prod-logs: ## Follow logs for SERVICE in the local production-like runtime
+	@$(call log_target,prod-logs SERVICE=$(SERVICE))
+	$(DOCKER_COMPOSE) \
+		--env-file $(ENV_FILE) \
+		-f $(PROD_COMPOSE_FILE) \
+		logs -f -t $(SERVICE)

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -3,13 +3,13 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 .PHONY: prod-help prod-prepare-runtime prod-compose-config prod-build
-.PHONY: prod-start prod-stop prod-down prod-ps prod-logs
+.PHONY: prod-start prod-stop prod-down prod-ps prod-logs prod-clean
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
 PROD_COMPOSE_FILE ?= docker/prod/docker-compose.yaml
 PROD_PROFILE ?= ptf
-PROD_PROJECT_NAME ?= trafic-cycliste-prod
+PROD_PROJECT_NAME ?= bike-traffic-prod
 SERVICE ?= api-dev
 
 prod_log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
@@ -51,7 +51,7 @@ prod-build: prod-prepare-runtime ## Build local production-like Docker images
 	$(prod_compose) --profile all build
 
 prod-start: prod-compose-config ## Start local production-like platform services
-	@$(call prod_log_target,prod-ops PROD_PROFILE=$(PROD_PROFILE))
+	@$(call prod_log_target,prod-start PROD_PROFILE=$(PROD_PROFILE))
 	$(prod_compose) --profile $(PROD_PROFILE) up -d
 
 prod-stop: ## Stop local production-like services for the selected profile
@@ -69,3 +69,7 @@ prod-ps: ## Show local production-like service status
 prod-logs: ## Follow logs for SERVICE in the local production-like runtime
 	@$(call prod_log_target,prod-logs SERVICE=$(SERVICE))
 	$(prod_compose) logs -f -t $(SERVICE)
+
+prod-clean: ## Remove Docker artifacts, including images and volumes
+	@$(call log_test,prod-clean)
+	$(prod_compose) --profile all down -v --rmi all

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -2,8 +2,8 @@ SHELL := /bin/bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: prod-help prod-compose-config prod-build prod-ops prod-stop
-.PHONY: prod-down prod-ps prod-logs
+.PHONY: prod-help prod-prepare-runtime prod-compose-config prod-build
+.PHONY: prod-ops prod-stop prod-down prod-ps prod-logs
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
@@ -28,12 +28,24 @@ prod-help: ## Display local production-like runtime targets
 		} \
 	' $(MAKEFILE_LIST)
 
-prod-compose-config: ## Validate the local production-like Compose config
+prod-prepare-runtime: ## Create ignored local production-like runtime folders
+	@$(call prod_log_target,prod-prepare-runtime)
+	mkdir -p \
+		docker/prod/runtime/data/raw \
+		docker/prod/runtime/data/interim \
+		docker/prod/runtime/data/processed \
+		docker/prod/runtime/data/final \
+		docker/prod/runtime/models \
+		docker/prod/runtime/logs/api \
+		docker/prod/runtime/logs/airflow \
+		docker/prod/runtime/logs/ml
+
+prod-compose-config: prod-prepare-runtime ## Validate the local production-like Compose config
 	@$(call prod_log_target,prod-compose-config)
 	@$(prod_check_env)
 	$(prod_compose) --profile all config >/dev/null
 
-prod-build: ## Build local production-like Docker images
+prod-build: prod-prepare-runtime ## Build local production-like Docker images
 	@$(call prod_log_target,prod-build)
 	@$(prod_check_env)
 	$(prod_compose) --profile all build

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -1,21 +1,26 @@
 SHELL := /bin/bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
-.DEFAULT_GOAL := help
 
-.PHONY: help prod-compose-config prod-build prod-ops prod-stop prod-down
-.PHONY: prod-ps prod-logs
+.PHONY: prod-help prod-compose-config prod-build prod-ops prod-stop
+.PHONY: prod-down prod-ps prod-logs
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
 PROD_COMPOSE_FILE ?= docker/prod/docker-compose.yaml
 PROD_PROFILE ?= ptf
+PROD_PROJECT_NAME ?= trafic-cycliste-prod
 SERVICE ?= api-dev
 
-log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
-check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
+prod_log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
+prod_check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
 
-help: ## Display local production-like runtime targets
+prod_compose = $(DOCKER_COMPOSE) \
+	--env-file $(ENV_FILE) \
+	-f $(PROD_COMPOSE_FILE) \
+	-p $(PROD_PROJECT_NAME)
+
+prod-help: ## Display local production-like runtime targets
 	@awk ' \
 		BEGIN {FS=":.*##"; printf "\nLocal production-like targets:\n\n"} \
 		/^[a-zA-Z0-9_.-]+:.*##/ { \
@@ -24,58 +29,31 @@ help: ## Display local production-like runtime targets
 	' $(MAKEFILE_LIST)
 
 prod-compose-config: ## Validate the local production-like Compose config
-	@$(call log_target,prod-compose-config)
-	@$(check_env)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile all \
-		config >/dev/null
+	@$(call prod_log_target,prod-compose-config)
+	@$(prod_check_env)
+	$(prod_compose) --profile all config >/dev/null
 
 prod-build: ## Build local production-like Docker images
-	@$(call log_target,prod-build)
-	@$(check_env)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile all \
-		build
+	@$(call prod_log_target,prod-build)
+	@$(prod_check_env)
+	$(prod_compose) --profile all build
 
 prod-ops: prod-compose-config ## Start local production-like platform services
-	@$(call log_target,prod-ops PROD_PROFILE=$(PROD_PROFILE))
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile $(PROD_PROFILE) \
-		up -d
+	@$(call prod_log_target,prod-ops PROD_PROFILE=$(PROD_PROFILE))
+	$(prod_compose) --profile $(PROD_PROFILE) up -d
 
 prod-stop: ## Stop local production-like services for the selected profile
-	@$(call log_target,prod-stop PROD_PROFILE=$(PROD_PROFILE))
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile $(PROD_PROFILE) \
-		stop
+	@$(call prod_log_target,prod-stop PROD_PROFILE=$(PROD_PROFILE))
+	$(prod_compose) --profile $(PROD_PROFILE) stop
 
 prod-down: ## Remove local production-like containers and networks
-	@$(call log_target,prod-down)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile all \
-		down
+	@$(call prod_log_target,prod-down)
+	$(prod_compose) --profile all down
 
 prod-ps: ## Show local production-like service status
-	@$(call log_target,prod-ps)
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		--profile all \
-		ps
+	@$(call prod_log_target,prod-ps)
+	$(prod_compose) --profile all ps
 
 prod-logs: ## Follow logs for SERVICE in the local production-like runtime
-	@$(call log_target,prod-logs SERVICE=$(SERVICE))
-	$(DOCKER_COMPOSE) \
-		--env-file $(ENV_FILE) \
-		-f $(PROD_COMPOSE_FILE) \
-		logs -f -t $(SERVICE)
+	@$(call prod_log_target,prod-logs SERVICE=$(SERVICE))
+	$(prod_compose) logs -f -t $(SERVICE)

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -60,7 +60,7 @@ prod-stop: ## Stop local production-like services for the selected profile
 
 prod-down: ## Remove local production-like containers and networks
 	@$(call prod_log_target,prod-down)
-	$(prod_compose) --profile all down
+	$(prod_compose) --profile all down --remove-orphans
 
 prod-ps: ## Show local production-like service status
 	@$(call prod_log_target,prod-ps)
@@ -70,6 +70,7 @@ prod-logs: ## Follow logs for SERVICE in the local production-like runtime
 	@$(call prod_log_target,prod-logs SERVICE=$(SERVICE))
 	$(prod_compose) logs -f -t $(SERVICE)
 
-prod-clean: ## Remove Docker artifacts, including images and volumes
-	@$(call log_test,prod-clean)
-	$(prod_compose) --profile all down -v --rmi all
+prod-clean: ## Remove production-like containers, networks, and volumes
+	@$(call prod_log_target,prod-clean)
+	@$(prod_check_env)
+	$(prod_compose) --profile all down -v --remove-orphans

--- a/docker/prod/README.md
+++ b/docker/prod/README.md
@@ -1,0 +1,45 @@
+# Local production-like Docker Compose runtime
+
+This folder contains the local production-like runtime introduced for Phase 7.
+
+It is intentionally separate from the root `docker-compose.yaml` and the
+`docker/dev` assets. The development runtime remains the correct target for
+interactive debugging, broad host visibility, and current DockerOperator-based
+Airflow ML jobs.
+
+## Validate
+
+```bash
+make -f docker/prod/Makefile prod-compose-config
+```
+
+## Start
+
+```bash
+make -f docker/prod/Makefile prod-ops
+```
+
+The default production-like profile is `ptf`. Override it when needed:
+
+```bash
+make -f docker/prod/Makefile prod-ops PROD_PROFILE=monitoring
+```
+
+## Stop
+
+```bash
+make -f docker/prod/Makefile prod-stop
+make -f docker/prod/Makefile prod-down
+```
+
+## Design constraints
+
+- Do not mount `/var/run/docker.sock` in Airflow.
+- Do not reuse the broad `mlops_net` development network.
+- Keep only local operator-facing services published to the host.
+- Prefer read-only runtime configuration mounts.
+- Keep temporary data, model, and log bind mounts documented until an artifact
+  handoff story replaces them.
+- Run custom API and ML containers as a non-root application user.
+
+See `docs/local-prod-runtime.md` for the full operating model and limitations.

--- a/docker/prod/README.md
+++ b/docker/prod/README.md
@@ -13,12 +13,6 @@ Airflow ML jobs.
 make prod-compose-config
 ```
 
-Equivalent explicit command:
-
-```bash
-make -f docker/prod/Makefile prod-compose-config
-```
-
 ## Start
 
 ```bash

--- a/docker/prod/README.md
+++ b/docker/prod/README.md
@@ -10,26 +10,32 @@ Airflow ML jobs.
 ## Validate
 
 ```bash
+make prod-compose-config
+```
+
+Equivalent explicit command:
+
+```bash
 make -f docker/prod/Makefile prod-compose-config
 ```
 
 ## Start
 
 ```bash
-make -f docker/prod/Makefile prod-ops
+make prod-start
 ```
 
 The default production-like profile is `ptf`. Override it when needed:
 
 ```bash
-make -f docker/prod/Makefile prod-ops PROD_PROFILE=monitoring
+make prod-start PROD_PROFILE=monitoring
 ```
 
 ## Stop
 
 ```bash
-make -f docker/prod/Makefile prod-stop
-make -f docker/prod/Makefile prod-down
+make prod-stop
+make prod-down
 ```
 
 ## Design constraints
@@ -38,8 +44,8 @@ make -f docker/prod/Makefile prod-down
 - Do not reuse the broad `mlops_net` development network.
 - Keep only local operator-facing services published to the host.
 - Prefer read-only runtime configuration mounts.
-- Keep temporary data, model, and log bind mounts documented until an artifact
-  handoff story replaces them.
+- Keep production-like generated artifacts under `docker/prod/runtime` until an
+  artifact handoff story replaces the temporary local workspace.
 - Run custom API and ML containers as a non-root application user.
 
 See `docs/local-prod-runtime.md` for the full operating model and limitations.

--- a/docker/prod/airflow/config/bike_dag_config.json
+++ b/docker/prod/airflow/config/bike_dag_config.json
@@ -1,0 +1,38 @@
+{
+  "scheduling": {
+    "initial_anchor_date": "2025-09-12",
+    "daily_increment_pct": 0.25
+  },
+  "counters": {
+    "Sebastopol_N-S_airflow": {
+      "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
+      "site": "Totem 73 boulevard de Sébastopol",
+      "orientation": "N-S",
+      "interim_name": "initial_airflow.csv",
+      "processed_name": "initial_airflow_with_feats.csv",
+      "final_basename": "y_full.csv",
+      "modeling": {
+        "ar": 7,
+        "mm": 1,
+        "roll": 24,
+        "test_ratio": 0.25,
+        "grid_iter": 0
+      }
+    },
+    "Sebastopol_S-N_airflow": {
+      "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
+      "site": "Totem 73 boulevard de Sébastopol",
+      "orientation": "S-N",
+      "interim_name": "initial_airflow.csv",
+      "processed_name": "initial_airflow_with_feats.csv",
+      "final_basename": "y_full.csv",
+      "modeling": {
+        "ar": 7,
+        "mm": 1,
+        "roll": 24,
+        "test_ratio": 0.25,
+        "grid_iter": 0
+      }
+    }
+  }
+}

--- a/docker/prod/airflow/config/connections.json
+++ b/docker/prod/airflow/config/connections.json
@@ -1,0 +1,10 @@
+{
+  "api_dev": {
+    "conn_type": "http",
+    "schema": "http",
+    "host": "api-dev",
+    "port": 10000,
+    "login": "[replace_me]",
+    "password": "[replace_me]"
+  }
+}

--- a/docker/prod/airflow/config/variables.json
+++ b/docker/prod/airflow/config/variables.json
@@ -1,0 +1,26 @@
+{
+  "docker_image_ingest": "ml-ingest:prod",
+  "docker_image_features": "ml-features:prod",
+  "docker_image_models": "ml-models:prod",
+  "docker_network": "pipeline_runtime_net",
+
+  "host_repo_root": "[replace_me]",
+  "container_repo_root": "/app",
+  "airflow_repo_root": "/opt/airflow",
+  "bike_dag_config": "/opt/airflow/config/bike_dag_config.json",
+  "default_counter_id": "Sebastopol_N-S_airflow",
+
+  "mlflow_tracking_uri": "http://mlflow-server:5000",
+  "mlflow_s3_endpoint_url": "http://mlflow-minio:9000",
+  "aws_access_key_id": "minio",
+  "aws_secret_access_key": "[replace_me]",
+  "aws_default_region": "us-east-1",
+
+  "airflow_uid": 1000,
+  "airflow_gid": 0,
+
+  "pushgateway_addr": "monitoring-pushgateway:9091",
+  "disable_metrics_push": "1",
+
+  "tz": "Europe/Paris"
+}

--- a/docker/prod/airflow/scripts/airflow-init.sh
+++ b/docker/prod/airflow/scripts/airflow-init.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running Airflow database migration"
+airflow db migrate
+
+echo "Importing Airflow variables"
+airflow variables import /opt/airflow/config/variables.json
+
+echo "Refreshing Airflow api_dev connection"
+airflow connections delete api_dev || true
+airflow connections import /opt/airflow/config/connections.json
+
+echo "Creating Airflow sequential_counters pool"
+airflow pools set \
+  sequential_counters \
+  2 \
+  "Orchestrator: trigger child DAGs sequentially"
+
+echo "Airflow initialization completed"

--- a/docker/prod/alertmanager/alertmanager.yml
+++ b/docker/prod/alertmanager/alertmanager.yml
@@ -1,0 +1,36 @@
+global:
+  smtp_smarthost: "monitoring-mailhog:1025"
+  smtp_from: "alerts@mlops.local"
+  smtp_require_tls: false
+
+route:
+  receiver: default
+  group_by: ["alertname"]
+  group_wait: 30s
+  group_interval: 1m
+  repeat_interval: 5m
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: critical-team
+      group_wait: 5s
+      group_interval: 15s
+      repeat_interval: 15s
+
+    - matchers:
+        - severity="warning"
+      receiver: warning-team
+      repeat_interval: 1h
+
+receivers:
+  - name: default
+    email_configs:
+      - to: "default@mlops.local"
+
+  - name: critical-team
+    email_configs:
+      - to: "critical@mlops.local"
+
+  - name: warning-team
+    email_configs:
+      - to: "warning@mlops.local"

--- a/docker/prod/api/Dockerfile
+++ b/docker/prod/api/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ARG APP_GID=1000
+ARG APP_UID=1000
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app
@@ -13,8 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY docker/dev/api/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN addgroup --system app && \
-    adduser --system --ingroup app --home /app app && \
+RUN groupadd --gid "${APP_GID}" app && \
+    useradd \
+        --uid "${APP_UID}" \
+        --gid "${APP_GID}" \
+        --home-dir /app \
+        --shell /usr/sbin/nologin \
+        app && \
     mkdir -p /app/src/api /app/logs/api /app/data/final && \
     chown -R app:app /app
 

--- a/docker/prod/api/Dockerfile
+++ b/docker/prod/api/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker/dev/api/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+RUN addgroup --system app && \
+    adduser --system --ingroup app --home /app app && \
+    mkdir -p /app/src/api /app/logs/api /app/data/final && \
+    chown -R app:app /app
+
+COPY src/api/main.py /app/src/api/main.py
+
+USER app
+
+EXPOSE 10000
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "10000"]

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -1,0 +1,565 @@
+# ========================
+# LOCAL PRODUCTION-LIKE RUNTIME
+# ========================
+# This Compose entrypoint is intentionally separate from the root development
+# runtime. It follows the functional network topology from docs/local-prod-
+# network-topology.md and keeps temporary exceptions documented in
+# docs/local-prod-runtime.md.
+
+volumes:
+  prod-mlflow-postgres-db:
+    name: prod-mlflow-postgres-db
+  prod-mlflow-minio-data:
+    name: prod-mlflow-minio-data
+  prod-airflow-postgres-db:
+    name: prod-airflow-postgres-db
+  prod-airflow-redis-data:
+    name: prod-airflow-redis-data
+  prod-prometheus-data:
+    name: prod-prometheus-data
+  prod-grafana-data:
+    name: prod-grafana-data
+  prod-alertmanager-data:
+    name: prod-alertmanager-data
+
+networks:
+  orchestration_net:
+    name: orchestration_net
+    driver: bridge
+  pipeline_runtime_net:
+    name: pipeline_runtime_net
+    driver: bridge
+  tracking_client_net:
+    name: tracking_client_net
+    driver: bridge
+  tracking_backend_net:
+    name: tracking_backend_net
+    driver: bridge
+  observability_net:
+    name: observability_net
+    driver: bridge
+  dev_support_net:
+    name: dev_support_net
+    driver: bridge
+
+x-prod-security: &prod-security
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges:true
+
+x-airflow-common: &airflow-common
+  image: ${AIRFLOW_IMAGE_NAME:?required}
+  environment: &airflow-common-env
+    AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${AIRFLOW_POSTGRES_USER:?required}:${AIRFLOW_POSTGRES_PASSWORD:?required}@airflow-postgres/${AIRFLOW_POSTGRES_DB:?required}
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${AIRFLOW_POSTGRES_USER:?required}:${AIRFLOW_POSTGRES_PASSWORD:?required}@airflow-postgres/${AIRFLOW_POSTGRES_DB:?required}
+    AIRFLOW__CELERY__BROKER_URL: redis://:@airflow-redis:6379/0
+    AIRFLOW__CORE__FERNET_KEY: "${AIRFLOW_FERNET_KEY:?required}"
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__CORE__AUTH_MANAGER: airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager
+    AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-api-server:8080/execution/
+    AIRFLOW__API__BASE_URL: http://airflow-api-server:8080
+    AIRFLOW__API_AUTH__JWT_SECRET: "${AIRFLOW_API_AUTH_JWT_SECRET:?required}"
+    AIRFLOW__SIMPLE_AUTH_MANAGER__USERS: "admin:admin"
+    AIRFLOW__SMTP__SMTP_HOST: "monitoring-mailhog"
+    AIRFLOW__SMTP__SMTP_PORT: 1025
+    AIRFLOW__SMTP__SMTP_MAIL_FROM: "airflow@test.local"
+    AIRFLOW__SMTP__SMTP_STARTTLS: "False"
+    AIRFLOW__SMTP__SMTP_SSL: "False"
+  user: "${AIRFLOW_UID:-50000}:0"
+  depends_on: &airflow-common-depends-on
+    airflow-redis:
+      condition: service_healthy
+    airflow-postgres:
+      condition: service_healthy
+  volumes:
+    - ../../logs:/opt/airflow/logs
+    - ../../data:/opt/airflow/data
+    - ../dev/airflow/dags:/opt/airflow/dags:ro
+    - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
+  networks:
+    - orchestration_net
+    - dev_support_net
+  profiles: ["all", "airflow", "ptf"]
+
+services:
+  # ========================
+  # BUSINESS SERVICES
+  # ========================
+  ml-ingest-prod:
+    <<: *prod-security
+    image: ml-ingest:prod
+    build:
+      context: ../..
+      dockerfile: ./docker/prod/ml/ingest/Dockerfile
+    command:
+      - --raw-path
+      - /app/data/raw/${RAW_FILE_NAME}
+      - --site
+      - ${SITE}
+      - --orientation
+      - ${ORIENTATION}
+      - --range-start
+      - "${RANGE_START}"
+      - --range-end
+      - "${RANGE_END}"
+      - --timestamp-col
+      - date_et_heure_de_comptage
+      - --sub-dir
+      - ${SUB_DIR}
+      - --interim-name
+      - ${INTERIM_NAME}
+    restart: "no"
+    environment:
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../logs:/app/logs
+    networks:
+      - pipeline_runtime_net
+    profiles: ["ml", "all"]
+
+  ml-features-prod:
+    <<: *prod-security
+    image: ml-features:prod
+    build:
+      context: ../..
+      dockerfile: ./docker/prod/ml/features/Dockerfile
+    command:
+      - --interim-path
+      - /app/data/interim/${SUB_DIR}/${INTERIM_NAME}
+      - --sub-dir
+      - ${SUB_DIR}
+      - --processed-name
+      - ${PROCESSED_NAME}
+      - --timestamp-col
+      - date_et_heure_de_comptage
+    restart: "no"
+    environment:
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../logs:/app/logs
+    networks:
+      - pipeline_runtime_net
+    profiles: ["ml", "all"]
+
+  ml-models-prod:
+    <<: *prod-security
+    image: ml-models:prod
+    build:
+      context: ../..
+      dockerfile: ./docker/prod/ml/models/Dockerfile
+    command:
+      - --processed-path
+      - /app/data/processed/${SUB_DIR}/${PROCESSED_NAME}
+      - --sub-dir
+      - ${SUB_DIR}
+      - --target-col
+      - comptage_horaire
+      - --ts-col-utc
+      - date_et_heure_de_comptage_utc
+      - --ts-col-local
+      - date_et_heure_de_comptage_local
+      - --ar
+      - "${AR}"
+      - --mm
+      - "${MM}"
+      - --roll
+      - "${ROLL}"
+      - --test-ratio
+      - "${TEST_RATIO}"
+      - --grid-iter
+      - "${GRID_ITER}"
+    restart: "no"
+    environment:
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
+      MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      GIT_PYTHON_REFRESH: quiet
+      PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
+      DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
+    volumes:
+      - ../../data:/app/data
+      - ../../models:/app/models
+      - ../../logs:/app/logs
+    networks:
+      - pipeline_runtime_net
+      - tracking_client_net
+    profiles: ["ml", "all"]
+
+  api-dev:
+    <<: *prod-security
+    image: api:prod
+    build:
+      context: ../..
+      dockerfile: ./docker/prod/api/Dockerfile
+    ports:
+      - "${API_HOST_PORT:-10000}:10000"
+    restart: unless-stopped
+    environment:
+      DATA_FINAL_ROOT: ${DATA_FINAL_ROOT}
+    volumes:
+      - ../../data/final:/app/data/final:ro
+      - ../../logs:/app/logs
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10000/docs', timeout=5).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - pipeline_runtime_net
+      - observability_net
+    profiles: ["all", "api", "ptf"]
+
+  # ========================
+  # MLFLOW SERVICES
+  # ========================
+  mlflow-postgres:
+    image: ${MLFLOW_POSTGRES_IMAGE:?required}
+    environment:
+      POSTGRES_USER: ${MLFLOW_POSTGRES_USER:?required}
+      POSTGRES_PASSWORD: ${MLFLOW_POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${MLFLOW_POSTGRES_DB:?required}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${MLFLOW_POSTGRES_USER:?required}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - prod-mlflow-postgres-db:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - tracking_backend_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-minio:
+    image: ${MLFLOW_MINIO_IMAGE:?required}
+    environment:
+      MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:?required}
+      MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:?required}
+    command: server /data --console-address ":9001"
+    volumes:
+      - prod-mlflow-minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - tracking_backend_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-mc-init:
+    image: ${MLFLOW_MINIO_MC_IMAGE:?required}
+    depends_on:
+      mlflow-minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set minio http://mlflow-minio:9000 ${AWS_ACCESS_KEY_ID:?required} ${AWS_SECRET_ACCESS_KEY:?required} &&
+      mc mb -p minio/mlflow || true &&
+      mc anonymous set download minio/mlflow || true &&
+      touch /tmp/ok && sleep 1
+      "
+    networks:
+      - tracking_backend_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  mlflow-server:
+    image: ${MLFLOW_IMAGE:?required}
+    depends_on:
+      mlflow-postgres:
+        condition: service_healthy
+      mlflow-minio:
+        condition: service_healthy
+      mlflow-mc-init:
+        condition: service_completed_successfully
+    environment:
+      MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
+      MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?required}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?required}
+      AWS_DEFAULT_REGION: us-east-1
+      GIT_PYTHON_REFRESH: quiet
+      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
+    ports:
+      - "${MLFLOW_HOST_PORT:-13001}:5000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health', timeout=5).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    command:
+      - mlflow
+      - server
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5000"
+      - --allowed-hosts
+      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
+    restart: unless-stopped
+    networks:
+      - tracking_client_net
+      - tracking_backend_net
+      - observability_net
+    profiles: ["all", "mlflow", "ptf"]
+
+  # ========================
+  # AIRFLOW SERVICES
+  # ========================
+  airflow-postgres:
+    image: ${AIRFLOW_POSTGRES_IMAGE:?required}
+    environment:
+      POSTGRES_USER: ${AIRFLOW_POSTGRES_USER:?required}
+      POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${AIRFLOW_POSTGRES_DB:?required}
+    volumes:
+      - prod-airflow-postgres-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${AIRFLOW_POSTGRES_USER:?required}"]
+      interval: 10s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - orchestration_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-redis:
+    image: ${AIRFLOW_REDIS_IMAGE:?required}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    volumes:
+      - prod-airflow-redis-data:/data
+    restart: unless-stopped
+    networks:
+      - orchestration_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-init:
+    <<: *airflow-common
+    environment:
+      <<: *airflow-common-env
+    command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
+    restart: "no"
+    volumes:
+      - ./airflow/config/:/opt/airflow/config/:ro
+      - ./airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-api-server:
+    <<: *airflow-common
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["api-server"]
+    ports:
+      - "${AIRFLOW_HOST_PORT:-12080}:8080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-scheduler:
+    <<: *airflow-common
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["scheduler"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-dag-processor:
+    <<: *airflow-common
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["dag-processor"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type DagProcessorJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-worker:
+    <<: *airflow-common
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    environment:
+      <<: *airflow-common-env
+    command: ["celery", "worker"]
+    healthcheck:
+      test: ["CMD-SHELL", "celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - orchestration_net
+      - pipeline_runtime_net
+      - dev_support_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-triggerer:
+    <<: *airflow-common
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["triggerer"]
+    healthcheck:
+      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    profiles: ["all", "airflow", "ptf"]
+
+  # ========================
+  # MONITORING SERVICES
+  # ========================
+  monitoring-prometheus:
+    image: ${PROMETHEUS_IMAGE:?required}
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - prod-prometheus-data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - observability_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-grafana:
+    image: ${GRAFANA_IMAGE:?required}
+    restart: unless-stopped
+    ports:
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - prod-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../dev/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    depends_on:
+      - monitoring-prometheus
+    networks:
+      - observability_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-cadvisor:
+    image: ${CADVISOR_IMAGE:?required}
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - observability_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-pushgateway:
+    image: ${PUSHGATEWAY_IMAGE:?required}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - pipeline_runtime_net
+      - observability_net
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-alertmanager:
+    image: ${ALERTMANAGER_IMAGE:?required}
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - prod-alertmanager-data:/alertmanager
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - observability_net
+      - dev_support_net
+    profiles: ["all", "monitoring", "ptf"]
+
+  monitoring-mailhog:
+    image: ${MAILHOG_IMAGE:?required}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - dev_support_net
+    profiles: ["all", "monitoring", "ptf"]

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -1,10 +1,9 @@
 # ========================
 # LOCAL PRODUCTION-LIKE RUNTIME
 # ========================
-# This Compose entrypoint is intentionally separate from the root development
-# runtime. It follows the functional network topology from docs/local-prod-
-# network-topology.md and keeps temporary exceptions documented in
-# docs/local-prod-runtime.md.
+# This runtime is intentionally separate from the root development runtime.
+# It follows docs/local-prod-network-topology.md and keeps the current runner
+# gap explicit in docs/local-prod-runtime.md.
 
 volumes:
   prod-mlflow-postgres-db:
@@ -75,8 +74,8 @@ x-airflow-common: &airflow-common
     airflow-postgres:
       condition: service_healthy
   volumes:
-    - ../../logs:/opt/airflow/logs
-    - ../../data:/opt/airflow/data
+    - ./runtime/logs/airflow:/opt/airflow/logs
+    - ./runtime/data:/opt/airflow/data
     - ../dev/airflow/dags:/opt/airflow/dags:ro
     - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
   networks:
@@ -116,8 +115,9 @@ services:
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
       DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
     volumes:
-      - ../../data:/app/data
-      - ../../logs:/app/logs
+      - ./runtime/data:/app/data
+      - ../../data/raw/${RAW_FILE_NAME}:/app/data/raw/${RAW_FILE_NAME}:ro
+      - ./runtime/logs/ml:/app/logs
     networks:
       - pipeline_runtime_net
     profiles: ["ml", "all"]
@@ -142,8 +142,8 @@ services:
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
       DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
     volumes:
-      - ../../data:/app/data
-      - ../../logs:/app/logs
+      - ./runtime/data:/app/data
+      - ./runtime/logs/ml:/app/logs
     networks:
       - pipeline_runtime_net
     profiles: ["ml", "all"]
@@ -185,9 +185,9 @@ services:
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR}
       DISABLE_METRICS_PUSH: ${DISABLE_METRICS_PUSH}
     volumes:
-      - ../../data:/app/data
-      - ../../models:/app/models
-      - ../../logs:/app/logs
+      - ./runtime/data:/app/data
+      - ./runtime/models:/app/models
+      - ./runtime/logs/ml:/app/logs
     networks:
       - pipeline_runtime_net
       - tracking_client_net
@@ -203,10 +203,10 @@ services:
       - "${API_HOST_PORT:-10000}:10000"
     restart: unless-stopped
     environment:
-      DATA_FINAL_ROOT: ${DATA_FINAL_ROOT}
+      DATA_FINAL_ROOT: /app/data/final
     volumes:
-      - ../../data/final:/app/data/final:ro
-      - ../../logs:/app/logs
+      - ./runtime/data/final:/app/data/final:ro
+      - ./runtime/logs/api:/app/logs
     healthcheck:
       test:
         - CMD-SHELL
@@ -225,28 +225,29 @@ services:
   # ========================
   mlflow-postgres:
     image: ${MLFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${MLFLOW_POSTGRES_USER:?required}
       POSTGRES_PASSWORD: ${MLFLOW_POSTGRES_PASSWORD:?required}
       POSTGRES_DB: ${MLFLOW_POSTGRES_DB:?required}
+    volumes:
+      - prod-mlflow-postgres-db:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${MLFLOW_POSTGRES_USER:?required}"]
       interval: 10s
       timeout: 5s
       retries: 5
-    volumes:
-      - prod-mlflow-postgres-db:/var/lib/postgresql/data
-    restart: unless-stopped
     networks:
       - tracking_backend_net
     profiles: ["all", "mlflow", "ptf"]
 
   mlflow-minio:
     image: ${MLFLOW_MINIO_IMAGE:?required}
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:?required}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:?required}
-    command: server /data --console-address ":9001"
     volumes:
       - prod-mlflow-minio-data:/data
     healthcheck:
@@ -255,7 +256,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     networks:
       - tracking_backend_net
     profiles: ["all", "mlflow", "ptf"]
@@ -278,6 +278,7 @@ services:
 
   mlflow-server:
     image: ${MLFLOW_IMAGE:?required}
+    restart: unless-stopped
     depends_on:
       mlflow-postgres:
         condition: service_healthy
@@ -285,6 +286,15 @@ services:
         condition: service_healthy
       mlflow-mc-init:
         condition: service_completed_successfully
+    command:
+      - mlflow
+      - server
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5000"
+      - --allowed-hosts
+      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
     environment:
       MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
       MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
@@ -303,16 +313,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    command:
-      - mlflow
-      - server
-      - --host
-      - 0.0.0.0
-      - --port
-      - "5000"
-      - --allowed-hosts
-      - ${MLFLOW_SERVER_ALLOWED_HOSTS:?required}
-    restart: unless-stopped
     networks:
       - tracking_client_net
       - tracking_backend_net
@@ -324,6 +324,7 @@ services:
   # ========================
   airflow-postgres:
     image: ${AIRFLOW_POSTGRES_IMAGE:?required}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${AIRFLOW_POSTGRES_USER:?required}
       POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:?required}
@@ -335,32 +336,31 @@ services:
       interval: 10s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-redis:
     image: ${AIRFLOW_REDIS_IMAGE:?required}
+    restart: unless-stopped
+    volumes:
+      - prod-airflow-redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    volumes:
-      - prod-airflow-redis-data:/data
-    restart: unless-stopped
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-init:
     <<: *airflow-common
+    restart: "no"
     environment:
       <<: *airflow-common-env
     command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
-    restart: "no"
     volumes:
       - ./airflow/config/:/opt/airflow/config/:ro
       - ./airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
@@ -368,6 +368,7 @@ services:
 
   airflow-api-server:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -381,11 +382,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-scheduler:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -397,11 +398,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-dag-processor:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -413,25 +414,24 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   airflow-worker:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
+    command: ["celery", "worker"]
     environment:
       <<: *airflow-common-env
-    command: ["celery", "worker"]
     healthcheck:
       test: ["CMD-SHELL", "celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     networks:
       - orchestration_net
       - pipeline_runtime_net
@@ -440,6 +440,7 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -451,7 +452,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    restart: unless-stopped
     profiles: ["all", "airflow", "ptf"]
 
   # ========================
@@ -479,12 +479,14 @@ services:
   monitoring-grafana:
     image: ${GRAFANA_IMAGE:?required}
     restart: unless-stopped
-    ports:
-      - "${GRAFANA_HOST_PORT:-14300}:3000"
+    depends_on:
+      - monitoring-prometheus
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
     volumes:
       - prod-grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
@@ -495,8 +497,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-    depends_on:
-      - monitoring-prometheus
     networks:
       - observability_net
     profiles: ["monitoring", "all", "ptf"]
@@ -536,10 +536,10 @@ services:
 
   monitoring-alertmanager:
     image: ${ALERTMANAGER_IMAGE:?required}
+    restart: unless-stopped
     volumes:
       - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - prod-alertmanager-data:/alertmanager
-    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
       interval: 10s

--- a/docker/prod/grafana/provisioning/datasources/datasource.yaml
+++ b/docker/prod/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://monitoring-prometheus:9090
+    isDefault: true
+    editable: true

--- a/docker/prod/ml/features/Dockerfile
+++ b/docker/prod/ml/features/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+COPY docker/dev/ml/features/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+RUN addgroup --system app && \
+    adduser --system --ingroup app --home /app app && \
+    mkdir -p /app/src/ml/features /app/data /app/logs && \
+    chown -R app:app /app
+
+COPY src/ml/features/features_utils.py /app/src/ml/features/features_utils.py
+COPY src/ml/features/build_features.py /app/src/ml/features/build_features.py
+
+USER app
+
+ENTRYPOINT ["python", "-m", "src.ml.features.build_features"]

--- a/docker/prod/ml/features/Dockerfile
+++ b/docker/prod/ml/features/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ARG APP_GID=1000
+ARG APP_UID=1000
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app
@@ -9,8 +12,13 @@ WORKDIR /app
 COPY docker/dev/ml/features/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN addgroup --system app && \
-    adduser --system --ingroup app --home /app app && \
+RUN groupadd --gid "${APP_GID}" app && \
+    useradd \
+        --uid "${APP_UID}" \
+        --gid "${APP_GID}" \
+        --home-dir /app \
+        --shell /usr/sbin/nologin \
+        app && \
     mkdir -p /app/src/ml/features /app/data /app/logs && \
     chown -R app:app /app
 

--- a/docker/prod/ml/ingest/Dockerfile
+++ b/docker/prod/ml/ingest/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+COPY docker/dev/ml/ingest/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+RUN addgroup --system app && \
+    adduser --system --ingroup app --home /app app && \
+    mkdir -p /app/src/ml/ingest /app/data /app/logs && \
+    chown -R app:app /app
+
+COPY src/ml/ingest/ingest_utils.py /app/src/ml/ingest/ingest_utils.py
+COPY src/ml/ingest/import_raw_data.py /app/src/ml/ingest/import_raw_data.py
+
+USER app
+
+ENTRYPOINT ["python", "-m", "src.ml.ingest.import_raw_data"]

--- a/docker/prod/ml/ingest/Dockerfile
+++ b/docker/prod/ml/ingest/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ARG APP_GID=1000
+ARG APP_UID=1000
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app
@@ -9,8 +12,13 @@ WORKDIR /app
 COPY docker/dev/ml/ingest/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN addgroup --system app && \
-    adduser --system --ingroup app --home /app app && \
+RUN groupadd --gid "${APP_GID}" app && \
+    useradd \
+        --uid "${APP_UID}" \
+        --gid "${APP_GID}" \
+        --home-dir /app \
+        --shell /usr/sbin/nologin \
+        app && \
     mkdir -p /app/src/ml/ingest /app/data /app/logs && \
     chown -R app:app /app
 

--- a/docker/prod/ml/models/Dockerfile
+++ b/docker/prod/ml/models/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    GIT_PYTHON_REFRESH=quiet
+
+WORKDIR /app
+
+COPY docker/dev/ml/models/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+RUN addgroup --system app && \
+    adduser --system --ingroup app --home /app app && \
+    mkdir -p /app/src/ml/models /app/data /app/models /app/logs && \
+    chown -R app:app /app
+
+COPY src/ml/models/models_utils.py /app/src/ml/models/models_utils.py
+COPY src/ml/models/mlflow_tracking.py /app/src/ml/models/mlflow_tracking.py
+COPY src/ml/models/train_and_predict.py /app/src/ml/models/train_and_predict.py
+
+USER app
+
+ENTRYPOINT ["python", "-m", "src.ml.models.train_and_predict"]

--- a/docker/prod/ml/models/Dockerfile
+++ b/docker/prod/ml/models/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ARG APP_GID=1000
+ARG APP_UID=1000
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
@@ -10,8 +13,13 @@ WORKDIR /app
 COPY docker/dev/ml/models/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN addgroup --system app && \
-    adduser --system --ingroup app --home /app app && \
+RUN groupadd --gid "${APP_GID}" app && \
+    useradd \
+        --uid "${APP_UID}" \
+        --gid "${APP_GID}" \
+        --home-dir /app \
+        --shell /usr/sbin/nologin \
+        app && \
     mkdir -p /app/src/ml/models /app/data /app/models /app/logs && \
     chown -R app:app /app
 

--- a/docker/prod/prometheus/alert_rules.yml
+++ b/docker/prod/prometheus/alert_rules.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: api_alerts
+    rules:
+      - alert: ApiServiceDown
+        expr: up{instance=~".*api-dev.*"} == 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "API service is down"
+          description: "The API service has been unreachable for 30 seconds."
+
+      - alert: ApiServiceUnstable
+        expr: changes(up{instance=~".*api-dev.*"}[5m]) > 3
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API service is unstable"
+          description: "The API service changed availability too often."

--- a/docker/prod/prometheus/prometheus.yml
+++ b/docker/prod/prometheus/prometheus.yml
@@ -1,0 +1,32 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 5s
+  evaluation_interval: 5s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - "monitoring-alertmanager:9093"
+
+rule_files:
+  - "alert_rules.yml"
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["monitoring-prometheus:9090"]
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["monitoring-cadvisor:8080"]
+
+  - job_name: api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api-dev:10000"]
+
+  - job_name: pushgateway
+    honor_labels: true
+    static_configs:
+      - targets: ["monitoring-pushgateway:9091"]

--- a/docker/prod/runtime/.gitignore
+++ b/docker/prod/runtime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/dependency-strategy.md
+++ b/docs/dependency-strategy.md
@@ -43,23 +43,31 @@ own minimal requirements files or use upstream images.
 Custom images are the runtime source of truth for services built by this
 repository.
 
-| Service image | Dockerfile | Requirements file | Python baseline |
-| ------------- | ---------- | ----------------- | --------------- |
-| API | `docker/dev/api/Dockerfile` | `docker/dev/api/requirements.txt` | Python 3.12 |
-| ML ingest | `docker/dev/ml/ingest/Dockerfile` | `docker/dev/ml/ingest/requirements.txt` | Python 3.12 |
-| ML features | `docker/dev/ml/features/Dockerfile` | `docker/dev/ml/features/requirements.txt` | Python 3.12 |
-| ML models | `docker/dev/ml/models/Dockerfile` | `docker/dev/ml/models/requirements.txt` | Python 3.12 |
+| Service image | Runtime | Dockerfile | Requirements file | Python baseline |
+| ------------- | ------- | ---------- | ----------------- | --------------- |
+| API | Dev | `docker/dev/api/Dockerfile` | `docker/dev/api/requirements.txt` | Python 3.12 |
+| ML ingest | Dev | `docker/dev/ml/ingest/Dockerfile` | `docker/dev/ml/ingest/requirements.txt` | Python 3.12 |
+| ML features | Dev | `docker/dev/ml/features/Dockerfile` | `docker/dev/ml/features/requirements.txt` | Python 3.12 |
+| ML models | Dev | `docker/dev/ml/models/Dockerfile` | `docker/dev/ml/models/requirements.txt` | Python 3.12 |
+| API | Prod-like | `docker/prod/api/Dockerfile` | `docker/dev/api/requirements.txt` | Python 3.12 |
+| ML ingest | Prod-like | `docker/prod/ml/ingest/Dockerfile` | `docker/dev/ml/ingest/requirements.txt` | Python 3.12 |
+| ML features | Prod-like | `docker/prod/ml/features/Dockerfile` | `docker/dev/ml/features/requirements.txt` | Python 3.12 |
+| ML models | Prod-like | `docker/prod/ml/models/Dockerfile` | `docker/dev/ml/models/requirements.txt` | Python 3.12 |
 
 The standard baseline for custom images is Python 3.12. A different Python
 version should only be used if a service-specific dependency constraint requires
 it and the reason is documented.
 
+The prod-like Dockerfiles currently reuse the same requirements files as the dev
+images to avoid dependency drift while the runtime boundary is being introduced.
+A future hardening story may split requirements only when the operational need is
+clear and validated.
+
 ## Compose runtime image policy
 
-Runtime image variables are centralized in `.env.template` and consumed by
-`docker-compose.yaml` with `:?required` guards. They keep readable version tags
-for local developer ergonomics and for tools such as the VS Code Docker
-extension.
+Runtime image variables are centralized in `.env.template` and consumed by the
+Compose entrypoints with `:?required` guards. They keep readable version tags for
+local developer ergonomics and for tools such as the VS Code Docker extension.
 
 Validated content digests are documented here when known. A future production
 hardening phase may replace readable tags with direct `@sha256:` image
@@ -88,10 +96,10 @@ uv environment.
 
 | Service family | Current image policy |
 | -------------- | -------------------- |
-| Orchestration Services | Uses `Airflow`, `PostgreSQL`, `Redis` images |
-| Experimentation Services | Uses `MLFlow`, `PostgreSQL`, `Minio`, `MC` images |
-| Monitoring Services | Uses `Prometheus`, `Grafana`, `Pushgateway`, `Alertmanager`, `cAdvisor` images |
-| Development helpers | Uses `MailHog` images |
+| Orchestration services | Uses Airflow, PostgreSQL, and Redis images |
+| Experimentation services | Uses MLflow, PostgreSQL, MinIO, and MC images |
+| Monitoring services | Uses Prometheus, Grafana, Pushgateway, Alertmanager, and cAdvisor images |
+| Development helpers | Uses MailHog images |
 
 ## Healthchecks
 
@@ -101,6 +109,7 @@ it is part of the selected image.
 
 | Service | Healthcheck strategy |
 | ------- | -------------------- |
+| `api-dev` | Python `urllib` read check on `/docs`. |
 | `mlflow-postgres` | `pg_isready` against the MLflow metadata database. |
 | `mlflow-minio` | curl check on `/minio/health/live`. |
 | `mlflow-server` | Python `urllib` read check on `/health`. |
@@ -109,15 +118,15 @@ it is part of the selected image.
 | `airflow-api-server` | curl check on `/api/v2/monitor/health`. |
 | `airflow-scheduler` | `airflow jobs check --job-type SchedulerJob`. |
 | `airflow-dag-processor` | `airflow jobs check --job-type DagProcessorJob`. |
-| `airflow-worker` | Celery ping executed as the `airflow` user because the worker container entrypoint starts as root only to adjust Docker socket access. |
+| `airflow-worker` | Celery ping. The dev worker executes the check as the `airflow` user because its entrypoint starts as root only to adjust Docker socket access. |
 | `airflow-triggerer` | `airflow jobs check --job-type TriggererJob`. |
-| `airflow-flower` | curl check on `/`. |
+| `airflow-flower` | curl check on `/` in the dev runtime. |
 | `monitoring-prometheus` | wget check on `/-/ready`. |
 | `monitoring-grafana` | wget check on `/api/health`. |
 | `monitoring-pushgateway` | wget check on `/-/ready`. |
 | `monitoring-alertmanager` | wget check on `/-/ready`. |
 | `monitoring-cadvisor` | wget check on `/healthz`. |
-| `mailhog` | curl check on `/`. |
+| `monitoring-mailhog` | wget check on `/`. |
 
 ## Runtime-sensitive dependencies
 
@@ -176,18 +185,23 @@ Before merging a runtime dependency upgrade, validate at least:
 ```bash
 make sync
 make lint
-make test
-make compose-config
-make build
-make start PROFILE=ptf
-make mlops-pipeline
-make logs SERVICE=api-dev
+make tests
+make dev-compose-config
+make prod-compose-config
+make dev-build
+make prod-build
+make dev-start DEV_PROFILE=ptf
+make prod-start PROD_PROFILE=ptf
+make dev-mlops-pipeline
+make dev-logs SERVICE=api-dev
 ```
 
 Then verify:
 
-- prediction files are produced under `data/final`;
-- model artifacts are produced under `models`;
+- prediction files are produced under root `data/final` for the development
+  runtime;
+- production-like generated artifacts stay under `docker/prod/runtime`;
+- model artifacts are produced under root `models` for the development runtime;
 - MLflow runs contain expected parameters, metrics, and artifacts;
 - API `/docs` is reachable;
 - API prediction endpoints still return the expected schema;

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -29,24 +29,15 @@ The root Makefile now includes the dedicated runtime Makefiles:
 - `docker/dev/Makefile` for local development Compose operations;
 - `docker/prod/Makefile` for local production-like Compose operations.
 
-Root aliases keep existing habits stable while making the active runtime clear:
-
-```bash
-make compose-config     # delegates to make dev-compose-config
-make ops                # delegates to make dev-ops
-make build              # delegates to make dev-build
-make mlops-pipeline     # delegates to make dev-mlops-pipeline
-```
-
 Explicit runtime commands are preferred for cross-checks:
 
 ```bash
 make dev-compose-config
-make dev-ops
+make dev-start
 make dev-ps
 
 make prod-compose-config
-make prod-ops
+make prod-start
 make prod-ps
 ```
 
@@ -195,7 +186,6 @@ injection mechanism before running authenticated flows.
 Minimum validation for this story:
 
 ```bash
-make compose-config
 make dev-compose-config
 make prod-compose-config
 ```
@@ -203,8 +193,8 @@ make prod-compose-config
 Additional local smoke checks after startup:
 
 ```bash
-make dev-ops
-make prod-ops
+make dev-start
+make prod-start
 make prod-ps
 
 docker compose --env-file .env -f docker/prod/docker-compose.yaml \

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -1,57 +1,97 @@
-# Local production-like Compose runtime
+# Local Compose runtimes
 
 This document is the Phase 7 implementation note for issue #57. It introduces
-and explains the separate local production-like Docker Compose entrypoint under
-`docker/prod`.
+and explains the symmetric local Docker Compose runtime layout under
+`docker/dev` and `docker/prod`.
 
-The current root `docker-compose.yaml` and `docker/dev` runtime remain the local
-development runtime. They optimize for debugging, host visibility, live-mounted
-runtime assets, and direct inspection of local service UIs.
-
-The `docker/prod` runtime optimizes for a different goal: it gives the project a
-local target that is closer to a production operating model while still running
-on a single developer host.
+The development runtime optimizes for debugging, host visibility, live-mounted
+runtime assets, and direct inspection of local service UIs. The production-like
+runtime optimizes for stricter local operation, reduced host exposure, functional
+networks, non-root custom application images, and explicit temporary exceptions.
 
 ## When to use each runtime
 
 | Runtime | Entry point | Primary use |
 | ------- | ----------- | ----------- |
-| Development | `docker-compose.yaml` | Debugging, local demos, broad host visibility, DockerOperator-based Airflow ML jobs. |
+| Development | `docker/dev/docker-compose.yaml` | Debugging, local demos, broad host visibility, DockerOperator-based Airflow ML jobs. |
+| Compatibility dev entrypoint | `docker-compose.yaml` | Existing habits and raw `docker compose` commands from the repository root. |
 | Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, monitoring smoke tests, future runner integration. |
 
-Use `docker/dev` when iterating on DAGs, ML CLI containers, data files, logs, or
-model outputs. Use `docker/prod` when validating service boundaries, reduced
-host exposure, non-root application containers, and the future runner migration
-path.
+Use `docker/dev` when iterating on DAGs, ML CLI containers, root-level DVC data,
+logs, or model outputs. Use `docker/prod` when validating service boundaries,
+reduced host exposure, non-root application containers, isolated runtime
+workspaces, and the future runner migration path.
 
 ## Operational commands
 
-The local production-like runtime has a dedicated Makefile so the root Makefile
-and the current development workflow stay unchanged.
+The root Makefile now includes the dedicated runtime Makefiles:
+
+- `docker/dev/Makefile` for local development Compose operations;
+- `docker/prod/Makefile` for local production-like Compose operations.
+
+Root aliases keep existing habits stable while making the active runtime clear:
 
 ```bash
-make -f docker/prod/Makefile prod-compose-config
-make -f docker/prod/Makefile prod-ops
-make -f docker/prod/Makefile prod-ps
-make -f docker/prod/Makefile prod-logs SERVICE=api-dev
-make -f docker/prod/Makefile prod-stop
+make compose-config     # delegates to make dev-compose-config
+make ops                # delegates to make dev-ops
+make build              # delegates to make dev-build
+make mlops-pipeline     # delegates to make dev-mlops-pipeline
 ```
 
-The equivalent raw Compose validation command is:
+Explicit runtime commands are preferred for cross-checks:
+
+```bash
+make dev-compose-config
+make dev-ops
+make dev-ps
+
+make prod-compose-config
+make prod-ops
+make prod-ps
+```
+
+Equivalent raw Compose validation commands:
 
 ```bash
 docker compose \
     --env-file .env \
+    -f docker/dev/docker-compose.yaml \
+    -p trafic-cycliste-dev \
+    --profile all \
+    config
+
+docker compose \
+    --env-file .env \
     -f docker/prod/docker-compose.yaml \
+    -p trafic-cycliste-prod \
     --profile all \
     config
 ```
 
-The existing validation command remains valid for the development runtime:
+## Runtime workspace strategy
 
-```bash
-make compose-config
+The root `data`, `models`, and `logs` folders remain development, DVC, and
+host-local workspaces. They are still used by the development runtime and by
+local Python/DVC commands.
+
+The local production-like runtime writes to ignored runtime workspaces under
+`docker/prod/runtime`:
+
+| Path | Purpose |
+| ---- | ------- |
+| `docker/prod/runtime/data` | Production-like generated data workspace. |
+| `docker/prod/runtime/models` | Production-like generated model workspace. |
+| `docker/prod/runtime/logs` | Production-like service and batch logs. |
+
+Only the required business source CSV is mounted from the root development/DVC
+workspace into the production-like ingestion service as read-only input:
+
+```text
+data/raw/comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv
 ```
+
+This keeps DVC ownership local to the root workspace while allowing `docker/prod`
+to run without writing into root `data`, `models`, or `logs`.
 
 ## Network topology
 
@@ -67,7 +107,9 @@ The `docker/prod` Compose file follows the target functional network design from
 | `observability_net` | Prometheus scrapes, Grafana datasource access, and alert routing. |
 | `dev_support_net` | Local SMTP capture for Airflow and Alertmanager. |
 
-The broad development `mlops_net` is not used by `docker/prod`.
+The broad development `mlops_net` remains available in `docker/dev` because the
+current Airflow DockerOperator path depends on the development network model. It
+is not used by `docker/prod`.
 
 ## Worker-pool status
 
@@ -110,17 +152,15 @@ and PostgreSQL services stay internal in `docker/prod`.
 
 ## Mount strategy
 
-The production-like runtime reduces direct host mounts, but it does not remove
-all artifact mounts in the first implementation.
-
-| Mount | Status | Reason |
-| ----- | ------ | ------ |
-| `data/final` into API | Read-only | API serving needs promoted prediction artifacts. |
-| `data` into ML one-off services | Writable temporary exception | The runner and artifact handoff contract are not implemented yet. |
-| `models` into model service | Writable temporary exception | Model artifacts still use the local workspace. |
-| `logs` into API, Airflow, and ML services | Writable temporary exception | Local log inspection remains the current evidence path. |
-| Airflow DAG/config files | Read-only | DAG and config placement is explicit for this runtime. |
-| Monitoring configs | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
+| Mount | Runtime | Status | Reason |
+| ----- | ------- | ------ | ------ |
+| Root `data`, `models`, `logs` | Dev | Writable | Debug visibility, local DVC, and current DockerOperator jobs. |
+| Root source CSV | Prod | Read-only | Required business input for ingestion. |
+| `docker/prod/runtime/data` | Prod | Writable | Temporary production-like data workspace. |
+| `docker/prod/runtime/models` | Prod | Writable | Temporary production-like model workspace. |
+| `docker/prod/runtime/logs` | Prod | Writable | Temporary production-like log workspace. |
+| Airflow DAG/config files | Prod | Read-only | DAG and config placement is explicit for this runtime. |
+| Monitoring configs | Prod | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
 
 The expected next hardening step is an explicit artifact handoff contract using
 object storage, release manifests, or a promotion service.
@@ -129,6 +169,8 @@ object storage, release manifests, or a promotion service.
 
 Custom API and ML containers run as a non-root application user in
 `docker/prod`. They also drop Linux capabilities and use `no-new-privileges`.
+The prod Dockerfiles default this user to UID/GID `1000` to keep local bind-mount
+writes compatible with common developer hosts.
 
 Documented exceptions:
 
@@ -141,8 +183,8 @@ Documented exceptions:
 
 ## Secrets and placeholders
 
-`docker/prod` still reads `.env` from the repository root. Do not commit a
-populated `.env` file.
+`docker/dev` and `docker/prod` still read `.env` from the repository root. Do not
+commit a populated `.env` file.
 
 The production-like Airflow config uses placeholder credentials where values are
 not safe to commit. Replace placeholders in a local branch or use a future secret
@@ -154,24 +196,28 @@ Minimum validation for this story:
 
 ```bash
 make compose-config
-make -f docker/prod/Makefile prod-compose-config
+make dev-compose-config
+make prod-compose-config
 ```
 
 Additional local smoke checks after startup:
 
 ```bash
-make -f docker/prod/Makefile prod-ops
-make -f docker/prod/Makefile prod-ps
+make dev-ops
+make prod-ops
+make prod-ps
 
 docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    exec monitoring-prometheus wget -qO- http://api-dev:10000/metrics
+    -p trafic-cycliste-prod exec monitoring-prometheus \
+    wget -qO- http://api-dev:10000/metrics
 
 docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    exec monitoring-grafana wget -qO- http://monitoring-prometheus:9090/-/ready
+    -p trafic-cycliste-prod exec monitoring-grafana \
+    wget -qO- http://monitoring-prometheus:9090/-/ready
 
 docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    exec mlflow-server getent hosts mlflow-postgres
+    -p trafic-cycliste-prod exec mlflow-server getent hosts mlflow-postgres
 
 docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    exec airflow-worker getent hosts api-dev
+    -p trafic-cycliste-prod exec airflow-worker getent hosts api-dev
 ```

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -41,24 +41,6 @@ make prod-start
 make prod-ps
 ```
 
-Equivalent raw Compose validation commands:
-
-```bash
-docker compose \
-    --env-file .env \
-    -f docker/dev/docker-compose.yaml \
-    -p trafic-cycliste-dev \
-    --profile all \
-    config
-
-docker compose \
-    --env-file .env \
-    -f docker/prod/docker-compose.yaml \
-    -p trafic-cycliste-prod \
-    --profile all \
-    config
-```
-
 ## Runtime workspace strategy
 
 The root `data`, `models`, and `logs` folders remain development, DVC, and

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -1,0 +1,177 @@
+# Local production-like Compose runtime
+
+This document is the Phase 7 implementation note for issue #57. It introduces
+and explains the separate local production-like Docker Compose entrypoint under
+`docker/prod`.
+
+The current root `docker-compose.yaml` and `docker/dev` runtime remain the local
+development runtime. They optimize for debugging, host visibility, live-mounted
+runtime assets, and direct inspection of local service UIs.
+
+The `docker/prod` runtime optimizes for a different goal: it gives the project a
+local target that is closer to a production operating model while still running
+on a single developer host.
+
+## When to use each runtime
+
+| Runtime | Entry point | Primary use |
+| ------- | ----------- | ----------- |
+| Development | `docker-compose.yaml` | Debugging, local demos, broad host visibility, DockerOperator-based Airflow ML jobs. |
+| Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, monitoring smoke tests, future runner integration. |
+
+Use `docker/dev` when iterating on DAGs, ML CLI containers, data files, logs, or
+model outputs. Use `docker/prod` when validating service boundaries, reduced
+host exposure, non-root application containers, and the future runner migration
+path.
+
+## Operational commands
+
+The local production-like runtime has a dedicated Makefile so the root Makefile
+and the current development workflow stay unchanged.
+
+```bash
+make -f docker/prod/Makefile prod-compose-config
+make -f docker/prod/Makefile prod-ops
+make -f docker/prod/Makefile prod-ps
+make -f docker/prod/Makefile prod-logs SERVICE=api-dev
+make -f docker/prod/Makefile prod-stop
+```
+
+The equivalent raw Compose validation command is:
+
+```bash
+docker compose \
+    --env-file .env \
+    -f docker/prod/docker-compose.yaml \
+    --profile all \
+    config
+```
+
+The existing validation command remains valid for the development runtime:
+
+```bash
+make compose-config
+```
+
+## Network topology
+
+The `docker/prod` Compose file follows the target functional network design from
+`docs/local-prod-network-topology.md`.
+
+| Network | Main responsibility |
+| ------- | ------------------- |
+| `orchestration_net` | Airflow control plane, metadata DB, broker, and internal execution API. |
+| `pipeline_runtime_net` | API refresh, batch job handoff, and Pushgateway writes. |
+| `tracking_client_net` | MLflow client calls from model workloads. |
+| `tracking_backend_net` | MLflow PostgreSQL and MinIO backend isolation. |
+| `observability_net` | Prometheus scrapes, Grafana datasource access, and alert routing. |
+| `dev_support_net` | Local SMTP capture for Airflow and Alertmanager. |
+
+The broad development `mlops_net` is not used by `docker/prod`.
+
+## Worker-pool status
+
+The target worker-pool strategy from `docs/airflow-job-runner-strategy.md` is not
+fully implemented in this story. This runtime deliberately avoids pretending that
+the current DockerOperator path is production-like.
+
+Current behavior in `docker/prod`:
+
+- Airflow services do not mount `/var/run/docker.sock`.
+- The Airflow worker does not run through the development root entrypoint.
+- Production-like Airflow config points to `pipeline_runtime_net`, not
+  `mlops_net`.
+- Current DockerOperator-based ML DAG execution is a known temporary exception:
+  it remains available in `docker/dev`, not in `docker/prod`.
+
+Expected follow-up:
+
+1. Add typed job submission schemas and a runner client under `src/`.
+2. Add an internal `job-runner-api` and typed ML worker services.
+3. Update the production-like DAG variant to submit runner jobs instead of
+   creating containers.
+4. Validate init and daily DAGs through the runner before removing the temporary
+   exception from this document.
+
+## Host exposure
+
+The local production-like runtime publishes only operator-facing services needed
+for local validation by default:
+
+| Service | Reason |
+| ------- | ------ |
+| `api-dev` | Local prediction API, OpenAPI docs, and smoke tests. |
+| `airflow-api-server` | Local DAG inspection and orchestration UI. |
+| `mlflow-server` | Local tracking inspection while the model registry path matures. |
+| `monitoring-grafana` | Local dashboard entrypoint. |
+
+MinIO, Prometheus, Pushgateway, Alertmanager, MailHog, cAdvisor, Flower, Redis,
+and PostgreSQL services stay internal in `docker/prod`.
+
+## Mount strategy
+
+The production-like runtime reduces direct host mounts, but it does not remove
+all artifact mounts in the first implementation.
+
+| Mount | Status | Reason |
+| ----- | ------ | ------ |
+| `data/final` into API | Read-only | API serving needs promoted prediction artifacts. |
+| `data` into ML one-off services | Writable temporary exception | The runner and artifact handoff contract are not implemented yet. |
+| `models` into model service | Writable temporary exception | Model artifacts still use the local workspace. |
+| `logs` into API, Airflow, and ML services | Writable temporary exception | Local log inspection remains the current evidence path. |
+| Airflow DAG/config files | Read-only | DAG and config placement is explicit for this runtime. |
+| Monitoring configs | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
+
+The expected next hardening step is an explicit artifact handoff contract using
+object storage, release manifests, or a promotion service.
+
+## Runtime identities and exceptions
+
+Custom API and ML containers run as a non-root application user in
+`docker/prod`. They also drop Linux capabilities and use `no-new-privileges`.
+
+Documented exceptions:
+
+- Airflow uses the upstream Airflow image and its supported runtime user model.
+- cAdvisor remains privileged because local container metrics require access to
+  host and Docker runtime paths.
+- Infrastructure images such as PostgreSQL, Redis, MinIO, Prometheus, Grafana,
+  and Alertmanager keep their upstream image users unless a separate hardening
+  story validates a safer override.
+
+## Secrets and placeholders
+
+`docker/prod` still reads `.env` from the repository root. Do not commit a
+populated `.env` file.
+
+The production-like Airflow config uses placeholder credentials where values are
+not safe to commit. Replace placeholders in a local branch or use a future secret
+injection mechanism before running authenticated flows.
+
+## Validation checklist
+
+Minimum validation for this story:
+
+```bash
+make compose-config
+make -f docker/prod/Makefile prod-compose-config
+```
+
+Additional local smoke checks after startup:
+
+```bash
+make -f docker/prod/Makefile prod-ops
+make -f docker/prod/Makefile prod-ps
+
+docker compose --env-file .env -f docker/prod/docker-compose.yaml \
+    exec monitoring-prometheus wget -qO- http://api-dev:10000/metrics
+
+docker compose --env-file .env -f docker/prod/docker-compose.yaml \
+    exec monitoring-grafana wget -qO- http://monitoring-prometheus:9090/-/ready
+
+docker compose --env-file .env -f docker/prod/docker-compose.yaml \
+    exec mlflow-server getent hosts mlflow-postgres
+
+docker compose --env-file .env -f docker/prod/docker-compose.yaml \
+    exec airflow-worker getent hosts api-dev
+```

--- a/docs/ports-and-services.md
+++ b/docs/ports-and-services.md
@@ -1,8 +1,7 @@
 # Runtime ports and service exposure
 
-This document describes the local Docker Compose host port strategy. It is a
-local development convention only. It does not represent a production security
-model.
+This document describes local Docker Compose host port conventions. It is a
+local runtime convention only and does not represent a production security model.
 
 Docker services communicate through their internal container ports and Docker
 networks. The variables below only control ports published on the host machine.
@@ -18,7 +17,18 @@ networks. The variables below only control ports published on the host machine.
 | `14000-14999` | Observability and alerting |
 | `15000-15999` | Development-only helpers and debug tools |
 
-## Host-exposed services
+## Runtime scope
+
+The development runtime deliberately exposes more local UIs and debug endpoints
+than the local production-like runtime.
+
+| Runtime | Compose file | Exposure model |
+| ------- | ------------ | -------------- |
+| Development | `docker/dev/docker-compose.yaml` | Broad local UI and debug exposure. |
+| Compatibility dev entrypoint | `docker-compose.yaml` | Same development exposure from the repository root. |
+| Local production-like | `docker/prod/docker-compose.yaml` | Reduced host exposure for operator-facing services only. |
+
+## Development host-exposed services
 
 | Variable | Default | Service | Internal port | Reason |
 | -------- | ------- | ------- | ------------- | ------ |
@@ -36,51 +46,63 @@ networks. The variables below only control ports published on the host machine.
 | `MAILHOG_SMTP_HOST_PORT` | `15025` | `monitoring-mailhog` | `1025` | Local SMTP capture endpoint |
 | `MAILHOG_UI_HOST_PORT` | `15080` | `monitoring-mailhog` | `8025` | MailHog web UI |
 
+## Local production-like host-exposed services
+
+| Variable | Default | Service | Internal port | Reason |
+| -------- | ------- | ------- | ------------- | ------ |
+| `API_HOST_PORT` | `10000` | `api-dev` | `10000` | FastAPI prediction API and OpenAPI docs |
+| `AIRFLOW_HOST_PORT` | `12080` | `airflow-api-server` | `8080` | Airflow UI and API for local DAG operations |
+| `MLFLOW_HOST_PORT` | `13001` | `mlflow-server` | `5000` | MLflow tracking UI and host-side MLflow clients |
+| `GRAFANA_HOST_PORT` | `14300` | `monitoring-grafana` | `3000` | Grafana dashboards |
+
 ## Local URLs
 
 With the default `.env.template` values, the main local URLs are:
 
-| Service | URL |
-| ------- | --- |
-| FastAPI docs | `http://localhost:10000/docs` |
-| Airflow UI | `http://localhost:12080` |
-| Flower UI | `http://localhost:12555` |
-| MinIO API | `http://localhost:13000` |
-| MLflow UI | `http://localhost:13001` |
-| MinIO console | `http://localhost:13002` |
-| Prometheus UI | `http://localhost:14090` |
-| Pushgateway UI | `http://localhost:14091` |
-| Alertmanager UI | `http://localhost:14093` |
-| cAdvisor UI | `http://localhost:14200` |
-| Grafana UI | `http://localhost:14300` |
-| MailHog UI | `http://localhost:15080` |
+| Service | URL | Runtime |
+| ------- | --- | ------- |
+| FastAPI docs | `http://localhost:10000/docs` | Dev and prod-like |
+| Airflow UI | `http://localhost:12080` | Dev and prod-like |
+| Flower UI | `http://localhost:12555` | Dev only |
+| MinIO API | `http://localhost:13000` | Dev only |
+| MLflow UI | `http://localhost:13001` | Dev and prod-like |
+| MinIO console | `http://localhost:13002` | Dev only |
+| Prometheus UI | `http://localhost:14090` | Dev only |
+| Pushgateway UI | `http://localhost:14091` | Dev only |
+| Alertmanager UI | `http://localhost:14093` | Dev only |
+| cAdvisor UI | `http://localhost:14200` | Dev only |
+| Grafana UI | `http://localhost:14300` | Dev and prod-like |
+| MailHog UI | `http://localhost:15080` | Dev only |
 
 ## Internal-only services
 
-The following services are intentionally not published on host ports:
+The following service families are intentionally not published on host ports:
 
-| Service | Reason |
-| ------- | ------ |
-| `ml-ingest-dev` | One-off ML pipeline container triggered by Compose or Airflow |
-| `ml-features-dev` | One-off ML pipeline container triggered by Compose or Airflow |
-| `ml-models-dev` | One-off ML pipeline container triggered by Compose or Airflow |
-| `mlflow-postgres` | MLflow internal metadata database |
-| `mlflow-mc-init` | One-off MinIO initialization helper |
-| `airflow-postgres` | Airflow internal metadata database |
-| `airflow-redis` | Airflow Celery broker, used only inside `airflow_net` |
-| `airflow-init` | One-off Airflow initialization helper |
-| `airflow-scheduler` | Internal Airflow scheduler process |
-| `airflow-dag-processor` | Internal Airflow DAG parsing process |
-| `airflow-worker` | Internal Airflow Celery worker process |
-| `airflow-triggerer` | Internal Airflow async trigger process |
+| Service or family | Runtime | Reason |
+| ----------------- | ------- | ------ |
+| `ml-ingest-*` | Dev and prod-like | One-off ML pipeline container triggered by Compose or orchestration |
+| `ml-features-*` | Dev and prod-like | One-off ML pipeline container triggered by Compose or orchestration |
+| `ml-models-*` | Dev and prod-like | One-off ML pipeline container triggered by Compose or orchestration |
+| `mlflow-postgres` | Dev and prod-like | MLflow internal metadata database |
+| `mlflow-mc-init` | Dev and prod-like | One-off MinIO initialization helper |
+| `airflow-postgres` | Dev and prod-like | Airflow internal metadata database |
+| `airflow-redis` | Dev and prod-like | Airflow Celery broker |
+| `airflow-init` | Dev and prod-like | One-off Airflow initialization helper |
+| `airflow-scheduler` | Dev and prod-like | Internal Airflow scheduler process |
+| `airflow-dag-processor` | Dev and prod-like | Internal Airflow DAG parsing process |
+| `airflow-worker` | Dev and prod-like | Internal Airflow Celery worker process |
+| `airflow-triggerer` | Dev and prod-like | Internal Airflow async trigger process |
+| MinIO API and console | Prod-like | Internal artifact backend; host UI kept dev-only |
+| Prometheus, Pushgateway, Alertmanager, cAdvisor, MailHog | Prod-like | Internal support services; host UI kept dev-only except Grafana |
 
 `airflow-redis` used to publish `6379` on the host. It is now internal-only
 because no documented local workflow requires direct host access to the broker.
 
 ## Validation
 
-The expected configuration validation command is:
+The expected configuration validation commands are:
 
 ```bash
-make compose-config
+make dev-compose-config
+make prod-compose-config
 ```

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,27 +1,24 @@
 # Repository structure and runtime ownership
 
 This document clarifies how contributors should read and modify the repository
-while Phase 6 keeps the current local development runtime stable and prepares a
-future local production-like runtime.
-
-The goal is documentation and repository hygiene only. This story does not move
-large folders, restructure packages, or implement `docker/prod`.
+now that the project has symmetric local Compose runtime entrypoints for
+development and local production-like validation.
 
 ## Guiding rules
 
-- Keep the current `docker/dev` Compose workflow stable.
 - Use `src/` for reusable application, API, ML, metrics, and pipeline logic.
 - Keep deployment-specific Airflow DAGs close to their runtime assets.
-- Treat `data`, `logs`, and `models` as runtime workspaces, not normal source.
+- Treat root `data`, `logs`, and `models` as development and DVC workspaces.
+- Treat `docker/prod/runtime` as an ignored production-like runtime workspace.
 - Keep local environment files out of Git.
-- Introduce `docker/prod` only in a later production-like runtime story.
+- Keep dev and prod Compose files structurally comparable.
 
 ## Top-level responsibilities
 
 | Path | Responsibility |
 | ---- | -------------- |
 | `README.md` | Project entry point and links to detailed documentation. |
-| `Makefile` | Local setup, validation, DVC, and Docker Compose operation targets. |
+| `Makefile` | Repository setup, validation, DVC, and runtime Makefile inclusion. |
 | `.env.template` | Versioned template for local runtime variables. |
 | `.env` | Local-only runtime values created from `.env.template`. |
 | `pyproject.toml` | Local Python dependency groups and tooling configuration. |
@@ -30,9 +27,9 @@ large folders, restructure packages, or implement `docker/prod`.
 | `tests/` | Unit, integration, and regression tests. |
 | `docker/` | Dockerfiles, runtime config, Airflow DAG wiring, and service helpers. |
 | `docs/` | Architecture, operations, dependency, runtime, and repository docs. |
-| `data/` | Data workspace shared with local containers and DVC stages. |
-| `models/` | Generated model and forecast artifact workspace. |
-| `logs/` | Generated local runtime logs. |
+| `data/` | Development/DVC data workspace and root source input. |
+| `models/` | Development/DVC model and forecast artifact workspace. |
+| `logs/` | Development local runtime logs. |
 | `references/` | Static diagrams, exports, and explanatory material. |
 | `.dvc/` | DVC metadata and ignored local DVC state. |
 | `dvc.yaml` | Versioned DVC pipeline definition. |
@@ -52,22 +49,24 @@ large folders, restructure packages, or implement `docker/prod`.
 | `tests/` | Yes | No | No | No | No | No |
 | `docker-compose.yaml` | Yes | No | No | No | No | No |
 | `docker/dev/` | Yes | No | Partly | No | No | No |
-| `docker/prod/` | Planned | No | Planned | No | No | No |
+| `docker/prod/` | Yes | No | Partly | No | No | No |
+| `docker/prod/runtime/` | No | Yes | Yes | No | Yes | No |
 | `docker/common/` | Optional | No | Optional | No | No | No |
 | `docs/` | Yes | No | No | No | No | No |
 | `data/raw/` | Metadata or placeholders | Restored locally | Yes | Yes | Partly | No |
-| `data/interim/` | Metadata only | Yes | Yes | Yes | Partly | No |
-| `data/processed/` | Metadata only | Yes | Yes | Yes | Partly | No |
-| `data/final/` | Metadata only | Yes | Yes | Yes | Partly | No |
-| `models/` | Metadata only | Yes | Yes | Yes | Partly | No |
-| `logs/` | No | Yes | Yes | No | Yes | No |
+| `data/interim/` | Metadata only | Yes | Dev only | Yes | Partly | No |
+| `data/processed/` | Metadata only | Yes | Dev only | Yes | Partly | No |
+| `data/final/` | Metadata only | Yes | Dev only | Yes | Partly | No |
+| `models/` | Metadata only | Yes | Dev only | Yes | Partly | No |
+| `logs/` | No | Yes | Dev only | No | Yes | No |
 | `references/` | Yes | No | No | No | No | Yes |
 | `.dvc/config` | Yes | No | No | No | No | No |
 | `.dvc/config.local` | No | No | No | No | Yes | No |
 | `.dvc/cache/` | No | Yes | No | Local cache | Yes | No |
 
-`Partly` means a path can contain tracked placeholders or DVC metadata while
-large data payloads and runtime outputs remain ignored, restored, or reproduced.
+`Partly` means a path can contain tracked placeholders or runtime configuration
+while large data payloads and runtime outputs remain ignored, restored, or
+reproduced.
 
 ## Source code and runtime integration
 
@@ -81,28 +80,32 @@ They are coupled to local Airflow variables, connections, DockerOperator
 settings, service names, mounted paths, and the current worker model. They should
 not be moved into `src/` unless a separate packaging decision is made.
 
-DAG placement may differ between `docker/dev` and a future `docker/prod` area if
-operators, worker pools, queue names, image names, or artifact handoff mechanisms
-diverge.
+DAG placement may differ between `docker/dev` and `docker/prod` if operators,
+worker pools, queue names, image names, or artifact handoff mechanisms diverge.
 
 ## Docker runtime layout
 
 ### `docker/dev`
 
-`docker/dev` is the current local development runtime. It optimizes for host
+`docker/dev` is the canonical local development runtime. It optimizes for host
 visibility, debugging, demos, and fast iteration.
 
-It may use broad bind mounts such as `./data`, `./logs`, and `./models`, expose
+It may use broad bind mounts such as root `data`, `logs`, and `models`, expose
 local UIs, and keep Airflow DAGs, config files, and helper scripts close to the
 Airflow runtime that consumes them.
 
+The root `docker-compose.yaml` is kept as a compatibility entrypoint and mirrors
+the development runtime structure.
+
 ### `docker/prod`
 
-`docker/prod` is the expected future location for local production-like Compose
-assets. It should optimize for least privilege, reduced host mounts, stable
-service discovery, explicit artifact handoff, and narrower runtime boundaries.
+`docker/prod` is the local production-like Compose runtime. It optimizes for
+least privilege, reduced host mounts, stable service discovery, explicit
+workspace ownership, and narrower runtime boundaries.
 
-It is intentionally not implemented by this story.
+It writes generated operational data under `docker/prod/runtime`, which is
+ignored by Git and not DVC-managed. The only current root data dependency is the
+required source CSV mounted read-only from `data/raw` into the ingestion service.
 
 ### `docker/common`
 
@@ -115,8 +118,11 @@ runtime-specific clarity is preferable to premature abstraction.
 | Document or area | Responsibility |
 | ---------------- | -------------- |
 | `docs/repository-structure.md` | Repository paths, runtime ownership, artifacts, and dev/prod split. |
+| `docs/local-prod-runtime.md` | Dev/prod Compose operation model and local-prod constraints. |
 | `docs/runtime-communication-matrix.md` | Current service-to-service communication and mount coupling. |
 | `docs/runtime-security-boundaries.md` | Runtime identities and boundary design for Phase 6 and Phase 7. |
+| `docs/local-prod-network-topology.md` | Target local production-like network topology. |
+| `docs/airflow-job-runner-strategy.md` | Target Airflow job-runner worker-pool strategy. |
 | `docs/ports-and-services.md` | Host-exposed ports, local URLs, and internal-only services. |
 | `docs/dependency-strategy.md` | uv, image, dependency, and healthcheck strategy. |
 | `references/` | Static diagrams, exports, and explanatory assets. |
@@ -141,22 +147,27 @@ Directory expectations:
 
 - `data/raw/` contains input data restored locally or tracked through DVC
   metadata when needed.
-- `data/interim/`, `data/processed/`, and `data/final/` are generated pipeline
-  outputs restored, reproduced, or mounted by local runtime services.
-- `models/` is generated by training and prediction workflows.
-- `logs/` is generated by local services and batch jobs.
+- `data/interim/`, `data/processed/`, and `data/final/` are development and DVC
+  outputs restored, reproduced, or mounted by the development runtime.
+- `models/` is generated by development training and prediction workflows.
+- `logs/` is generated by local development services and batch jobs.
+- `docker/prod/runtime/data`, `docker/prod/runtime/models`, and
+  `docker/prod/runtime/logs` are production-like runtime outputs and are not
+  DVC-managed.
 - `.dvc/config` is versioned; `.dvc/config.local`, `.dvc/cache/`, and
   `.dvc/tmp/` are local-only.
 
-The current development runtime intentionally mounts `./data`, `./logs`, and
-`./models` for local visibility. A future production-like runtime should replace
-that broad visibility with explicit data release and artifact handoff contracts.
+The development runtime intentionally mounts root `data`, `logs`, and `models`
+for local visibility. The local production-like runtime avoids writing to those
+root workspaces and uses `docker/prod/runtime` instead until a stronger artifact
+handoff contract is introduced.
 
 ## Scripts and helper ownership
 
 A top-level `scripts/` folder, if introduced, should contain developer or
 operational helpers only. Runtime-specific helpers should stay near the runtime
-that executes them, for example under `docker/dev/airflow/scripts/`.
+that executes them, for example under `docker/dev/airflow/scripts/` or
+`docker/prod/airflow/scripts/`.
 
 Reusable business logic should live in `src/` with tests rather than in shell
 scripts or deployment folders.
@@ -165,8 +176,10 @@ scripts or deployment folders.
 
 - `.env.template` is versioned and contains placeholders or safe defaults.
 - `.env`, `.env.local`, `.env.dagshub`, and `.dvc/config.local` are local-only.
-- Runtime config files under `docker/dev/airflow/config/` may contain local IDs
-  or placeholders, but should not contain personal runtime values.
+- `docker/prod/runtime/` is local-only and ignored except for its `.gitignore`.
+- Runtime config files under `docker/dev/airflow/config/` and
+  `docker/prod/airflow/config/` may contain local placeholders, but should not
+  contain personal runtime values.
 
 ## Ignore-rule review
 
@@ -176,21 +189,23 @@ The current ignore strategy is consistent with this structure:
   files, `logs`, `mlruns`, and `mlflow.db`;
 - `.dvc/.gitignore` ignores local DVC config, cache, and temporary state;
 - `data/*/.gitignore` and `models/.gitignore` keep generated scenario outputs
-  out of normal Git commits.
+  out of normal Git commits;
+- `docker/prod/runtime/.gitignore` keeps production-like runtime outputs out of
+  Git and DVC ownership.
 
 There is no root `.dockerignore` at the time of this review. Adding one should
 be validated separately because current image build contexts rely on repository
 root visibility.
-
-No ignore-rule change is required in this story.
 
 ## Migration strategy
 
 Follow-up work should use this sequence:
 
 1. Keep `docker/dev` as the stable local development runtime.
-2. Design `docker/prod` as a separate local production-like runtime area.
-3. Define artifact handoff before reducing `data`, `logs`, or `models` mounts.
-4. Decide whether Airflow DAGs need separate dev and prod placement.
-5. Introduce `docker/common` only when concrete shared assets justify it.
-6. Update diagrams and operations docs after the target runtime is validated.
+2. Use `docker/prod` as the local production-like validation runtime.
+3. Keep root `data`, `logs`, and `models` dev/DVC-owned.
+4. Keep production-like generated outputs under `docker/prod/runtime`.
+5. Define artifact handoff before reducing remaining local runtime mounts.
+6. Decide whether Airflow DAGs need separate dev and prod placement.
+7. Introduce `docker/common` only when concrete shared assets justify it.
+8. Update diagrams and operations docs after the target runtime is validated.


### PR DESCRIPTION
## Summary

Implements the first local production-like Docker Compose runtime for issue #57 and harmonizes the existing development runtime so both can be compared more easily.

### Runtime layout

- Adds `docker/dev/docker-compose.yaml` as the canonical development Compose entrypoint.
- Keeps root `docker-compose.yaml` as a compatibility development entrypoint, now reformatted/aligned with `docker/dev`.
- Adds `docker/prod/docker-compose.yaml` as the local production-like Compose entrypoint.
- Adds dedicated runtime Makefiles:
  - `docker/dev/Makefile`
  - `docker/prod/Makefile`
- Updates the root `Makefile` to include runtime Makefiles while keeping repository-level setup, checks, local Python execution, DVC, and global clean helpers.
- Removes deprecated root Compose aliases such as `compose-config`, `build`, `ops`, `start`, `stop`, `logs`, `mlops-*`, `ci`, and `test` in favor of explicit runtime and repository targets.

### Dev runtime quality-of-life

- Reorders development Compose services/properties to match the production-like structure.
- Simplifies section comments.
- Adds a healthcheck for `api-dev`.
- Keeps development service names, networks, profiles, Docker socket behavior, and broad host mounts compatible with the current Airflow DockerOperator workflow.
- Adds runtime-scoped targets such as `dev-compose-config`, `dev-build`, `dev-start`, `dev-stop`, `dev-down`, `dev-clean`, `dev-logs`, and `dev-mlops-*`.

### Prod-like runtime

- Implements functional networks from the Phase 7 design:
  - `orchestration_net`
  - `pipeline_runtime_net`
  - `tracking_client_net`
  - `tracking_backend_net`
  - `observability_net`
  - `dev_support_net`
- Removes Docker socket access from the local-prod Airflow worker.
- Uses non-root custom API and ML images for the local-prod runtime.
- Reduces default host exposure to API, Airflow API, MLflow, and Grafana.
- Adds explicit local-prod Airflow config, monitoring config, placeholder credentials, and docs.
- Adds runtime-scoped targets such as `prod-compose-config`, `prod-build`, `prod-start`, `prod-stop`, `prod-down`, `prod-clean`, `prod-ps`, and `prod-logs`.

### Workspace strategy

- Keeps root `data`, `models`, and `logs` as dev/DVC/local-only workspaces.
- Adds ignored local-prod workspaces under `docker/prod/runtime`.
- Mounts only the required source CSV from root `data/raw` into the prod ingestion service as read-only input.
- Adds `prod-prepare-runtime` so local-prod runtime folders exist before Compose validation/startup.

### Clean strategy

- `dev-clean` and `prod-clean` are scoped to their Compose project: they remove project containers, networks, and volumes with `down -v --remove-orphans`.
- They intentionally do not remove shared upstream images, because these images can be referenced by the other runtime or by unrelated containers.
- `clean-docker` remains the global Docker garbage-collection target and only prunes unused Docker resources.

## Important implementation note

The full Airflow job-runner worker pool from issue #56 is not implemented yet. This PR deliberately documents that temporary exception instead of pretending that the current DockerOperator execution path is production-like. Current DockerOperator-based ML execution remains available through `docker/dev`; `docker/prod` is prepared for the future internal job-runner API and typed worker services.

## Validation

Expected local validation commands:

```bash
make dev-compose-config
make prod-compose-config
make checks
```

Additional checks after startup:

```bash
make dev-start
make prod-start
make dev-ps
make prod-ps
```

I could not execute Docker validation from this environment because the active sandbox cannot clone GitHub directly and has no local Docker project checkout. The branch diff was verified through the GitHub connector against `main`.

Closes #57
