### PR TITLE
[STORY] Phase 8 - Design hybrid artifact handoff contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ Runtime security boundaries and identities are documented in
 Runtime image, healthcheck, and dependency policies are documented in
 [`docs/dependency-strategy.md`](docs/dependency-strategy.md). Dev/prod Compose
 operation and workspace ownership are documented in
-[`docs/local-prod-runtime.md`](docs/local-prod-runtime.md).
+[`docs/local-prod-runtime.md`](docs/local-prod-runtime.md). Hybrid artifact
+promotion and local/object-storage handoff rules are documented in
+[`docs/artifact-handoff-strategy.md`](docs/artifact-handoff-strategy.md).
 
 For one-off ML pipeline containers in the development runtime, use:
 

--- a/docs/artifact-handoff-strategy.md
+++ b/docs/artifact-handoff-strategy.md
@@ -1,0 +1,301 @@
+# Hybrid artifact handoff strategy
+
+This document is the Phase 8 design artifact for issue #63. It defines the
+manifest-first contract used to hand off generated artifacts between ML jobs,
+Airflow, the future job runner, MLflow, optional MinIO object storage, and the
+FastAPI prediction service.
+
+The goal is design only. This story does not implement Python manifest models,
+manifest writers, MinIO upload helpers, API serving changes, or ML job changes.
+Those changes are intentionally split into later Phase 8 stories.
+
+## Decision summary
+
+The project uses a hybrid manifest-first strategy:
+
+1. The promotion manifest is the authority for served artifacts.
+2. `docker/prod/runtime` remains the first local production-like backend.
+3. Optional MinIO object URIs can be recorded when an artifact is also available
+   through S3-compatible object storage.
+4. The API, Airflow, and the future runner must consume manifests instead of
+   discovering files through implicit `latest` conventions.
+5. Development and DVC workspaces stay separate from production-like generated
+   runtime artifacts.
+
+This hybrid decision keeps Phase 8 incremental. The project can validate the
+production-like runtime with local bind-mounted artifacts first, while keeping a
+stable contract that can later point to MinIO without changing every consumer.
+
+## Scope and inputs
+
+The strategy builds on the current runtime documentation:
+
+| Source | Use in this design |
+| ------ | ------------------ |
+| `docs/local-prod-runtime.md` | Dev/prod runtime split and `docker/prod/runtime` ownership. |
+| `docs/repository-structure.md` | Repository path ownership and DVC boundary. |
+| `docs/ports-and-services.md` | Local host exposure and internal-only MinIO policy. |
+| `docs/dependency-strategy.md` | MLflow, MinIO, and runtime dependency compatibility. |
+| `docs/airflow-job-runner-strategy.md` | Target runner and worker-pool execution model. |
+| Phase 7 issue #57 | Production-like Compose runtime foundation. |
+
+## Why manifest-first
+
+The current development flow can tolerate visible folders and manual inspection.
+The production-like runtime needs a stricter handoff because implicit filesystem
+conventions create MLOps risks:
+
+| Risk | Manifest-first mitigation |
+| ---- | ------------------------- |
+| Consumers read different files as `latest`. | Consumers read the same promoted manifest. |
+| Artifact origin is unclear. | Manifest records producer, run ID, dataset version, and model version. |
+| Local and object storage paths drift. | Manifest stores local and optional object references together. |
+| API serving is coupled to folder layout. | API serving resolves an explicit promoted artifact reference. |
+| Airflow cannot audit what was served. | Airflow records or links the promoted manifest. |
+
+The manifest is not a metadata side file. It is the release contract for one
+promoted artifact.
+
+## Workspace boundary
+
+Root `data`, `models`, and `logs` remain development and DVC workspaces. They are
+valid for local experiments, DVC reproduction, notebook exploration, and the
+`docker/dev` runtime.
+
+`docker/prod/runtime` is the local production-like runtime workspace. It is
+ignored by Git, not DVC-managed, and owns generated artifacts produced while
+validating `docker/prod`.
+
+Consumers must not mix those boundaries:
+
+| Workspace | Owner | Main use | Promotion role |
+| --------- | ----- | -------- | -------------- |
+| `data/` | Development and DVC | Reproducible local data stages. | Source or comparison only. |
+| `models/` | Development and DVC | Reproducible local model outputs. | Source or comparison only. |
+| `logs/` | Development | Local service and batch logs. | No served artifact role. |
+| `docker/prod/runtime/data` | Local production-like runtime | Generated runtime data and predictions. | Local promoted artifacts. |
+| `docker/prod/runtime/models` | Local production-like runtime | Generated runtime model files. | Local promoted model references. |
+| `docker/prod/runtime/logs` | Local production-like runtime | Runtime logs. | Audit evidence only. |
+| MinIO object storage | MLflow or artifact backend | Optional S3-compatible storage. | Optional object reference. |
+
+## Artifact lifecycle
+
+Artifacts move through five logical states.
+
+| State | Meaning | Typical owner |
+| ----- | ------- | ------------- |
+| `produced` | A job wrote an output candidate and has enough metadata to describe it. | ML job or worker. |
+| `validated` | Required checks passed, including schema, checksum, and business validation. | ML job, worker, or validation step. |
+| `promoted` | A stable manifest pointer now marks the artifact as current. | Promotion helper or runner. |
+| `served` | The API has loaded or refreshed from the promoted manifest. | FastAPI service. |
+| `archived` | The artifact is retained for audit or rollback but is no longer current. | Artifact store or retention job. |
+
+Only `promoted` artifacts are eligible for default API serving. `served` is an
+operational observation, not a replacement for `promoted`.
+
+## Manifest ownership
+
+A manifest is created by the component that has the best evidence about the
+artifact:
+
+- ML prediction jobs know the output path, counter, dataset, model, metrics, and
+  checksum evidence.
+- A runner or promotion helper can validate the manifest and update the stable
+  promoted pointer.
+- Airflow orchestrates job order and records the manifest reference, but should
+  not fabricate artifact metadata that belongs to ML code.
+- The API reads the promoted manifest and must not guess file paths when the
+  manifest is available.
+
+The first implementation should write a real `current.json` file instead of a
+symlink. This is more portable across Windows, WSL, Docker bind mounts, and CI
+runners.
+
+## Local backend conventions
+
+Local production-like artifacts should stay under `docker/prod/runtime`.
+Recommended paths are:
+
+```text
+docker/prod/runtime/artifacts/
+├── manifests/
+│   ├── current.json
+│   └── runs/
+│       └── <run_id>/
+│           └── <artifact_type>-manifest.json
+├── data/
+│   └── final/
+│       └── <counter_id>/
+│           └── <run_id>/
+│               └── predictions.parquet
+└── models/
+    └── <counter_id>/
+        └── <model_version>/
+            └── model.joblib
+```
+
+The exact file format can evolve by artifact type. The manifest must stay stable
+enough for consumers to resolve the current artifact without scanning folders.
+
+Local paths stored in manifests should be repository-relative when possible, for
+example:
+
+```text
+docker/prod/runtime/artifacts/data/final/Sebastopol_N-S_airflow/2026-06-06T140000Z-sebastopol-ns/predictions.parquet
+```
+
+Absolute host paths should be avoided in versioned docs and manifests because
+they are not portable across developer machines, WSL, CI, or future runners.
+
+## Optional MinIO object URI conventions
+
+MinIO is optional in the handoff contract. A manifest can be local-only or hybrid.
+When an artifact is also uploaded to object storage, the manifest should include
+an S3-compatible URI.
+
+Recommended URI shape:
+
+```text
+s3://<bucket>/artifacts/<artifact_type>/<counter_id>/<run_id>/<file_name>
+```
+
+Example:
+
+```text
+s3://mlflow/artifacts/predictions/Sebastopol_N-S_airflow/2026-06-06T140000Z-sebastopol-ns/predictions.parquet
+```
+
+The URI records object identity. Credentials, endpoint URLs, and access keys must
+remain runtime configuration and must not be embedded in manifests.
+
+## Identifier conventions
+
+Identifiers must be deterministic enough for audit and safe enough for file paths
+or object keys.
+
+| Field | Convention | Example |
+| ----- | ---------- | ------- |
+| `run_id` | UTC timestamp plus a stable slug. | `2026-06-06T140000Z-sebastopol-ns` |
+| `counter_id` | Existing project counter identifier. | `Sebastopol_N-S_airflow` |
+| `dataset_version` | DVC revision, source snapshot label, or runtime input version. | `local-dev-dvc` |
+| `model_version` | MLflow run ID, registry version, or local model release label. | `mlflow-run-<short_sha>` |
+
+`run_id` values should be unique per external attempt. Airflow retries should
+include enough context to avoid overwriting previous attempts unless a deliberate
+idempotency rule returns the same job.
+
+## Manifest shape
+
+The initial manifest shape should remain JSON-compatible and map cleanly to
+future Pydantic models.
+
+```json
+{
+  "schema_version": "1.0",
+  "artifact_type": "predictions",
+  "status": "promoted",
+  "run_id": "2026-06-06T140000Z-sebastopol-ns",
+  "counter_id": "Sebastopol_N-S_airflow",
+  "created_at": "2026-06-06T14:00:00Z",
+  "producer": {
+    "service": "ml-models-prod",
+    "image": "ml-models:prod"
+  },
+  "source": {
+    "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
+    "dataset_version": "local-dev-dvc",
+    "model_version": "mlflow-run-20260606"
+  },
+  "storage": {
+    "primary_backend": "local",
+    "local_path": "docker/prod/runtime/artifacts/data/final/Sebastopol_N-S_airflow/2026-06-06T140000Z-sebastopol-ns/predictions.parquet",
+    "object_uri": "s3://mlflow/artifacts/predictions/Sebastopol_N-S_airflow/2026-06-06T140000Z-sebastopol-ns/predictions.parquet",
+    "checksum_sha256": "..."
+  }
+}
+```
+
+Expected storage rules:
+
+- `primary_backend` is `local` for the first implementation.
+- `local_path` is required while `docker/prod/runtime` is the serving backend.
+- `object_uri` is optional and can be omitted for local-only artifacts.
+- `checksum_sha256` should describe the referenced local artifact file, or the
+  canonical object payload once object storage becomes the primary backend.
+
+## Promotion rules
+
+A candidate artifact becomes current only when promotion updates the stable
+manifest pointer.
+
+Initial promotion rule:
+
+```text
+write candidate manifest -> validate -> write or replace current.json
+```
+
+Promotion must be atomic enough that consumers never observe a partially written
+`current.json`. The implementation story can choose a portable write strategy,
+for example writing to a temporary file and replacing the target file.
+
+Promotion must not happen when:
+
+- the manifest is invalid;
+- the referenced local artifact is missing;
+- the checksum does not match;
+- the artifact status is not eligible for serving;
+- required producer, source, or storage metadata is missing.
+
+## Component interactions
+
+| Component | Responsibility in the contract |
+| --------- | ------------------------------ |
+| ML jobs | Produce artifacts, compute checksums, emit candidate manifests. |
+| Runner | Execute typed jobs, persist job status, validate outputs, call promotion helpers. |
+| Airflow | Submit jobs, wait for terminal status, record manifest references. |
+| MLflow | Track runs, metrics, parameters, and model evidence. |
+| MinIO | Optionally store object-backed artifact payloads. |
+| API | Read `current.json`, validate metadata, serve the referenced artifact. |
+| Prometheus/Grafana | Observe freshness, job status, and current artifact metadata later. |
+
+The contract deliberately keeps Airflow out of low-level filesystem discovery and
+keeps the API out of training job internals.
+
+## Migration path
+
+Phase 8 should move in small validated steps:
+
+1. Document the contract and vocabulary in this file.
+2. Add strict Pydantic manifest models.
+3. Add manifest write, checksum, and promotion helpers.
+4. Make ML prediction jobs emit local-only manifests.
+5. Add typed job contracts and runner execution around manifest references.
+6. Make the API load the promoted local manifest instead of scanning folders.
+7. Add smoke validation proving runner, Airflow, API, and monitoring integration.
+8. Add optional MinIO upload/download helpers when the local contract is stable.
+9. Switch `primary_backend` from `local` to object storage only after API and
+   runner consumers support it.
+
+## Later stories consuming this contract
+
+Known Phase 8 consumers are:
+
+- #64: implement artifact manifest models and validation;
+- #65: implement artifact writer and promotion helpers;
+- #66: adapt the ML pipeline to emit artifact manifests;
+- #67: introduce typed pipeline job contracts;
+- #68: implement the internal job-runner API skeleton;
+- #69: execute typed ML jobs through the runner;
+- #70: add the production-like Airflow DAG using the runner API;
+- #71: make the API artifact-aware;
+- #72: add production-like smoke validation;
+- #73: harden runtime configuration and secrets validation.
+
+## Out of scope for this story
+
+- Python Pydantic schemas.
+- Manifest store implementation.
+- ML job manifest emission.
+- API serving changes.
+- MinIO upload/download helpers.
+- Production secret management.

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -135,8 +135,11 @@ and PostgreSQL services stay internal in `docker/prod`.
 | Airflow DAG/config files | Prod | Read-only | DAG and config placement is explicit for this runtime. |
 | Monitoring configs | Prod | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
 
-The expected next hardening step is an explicit artifact handoff contract using
-object storage, release manifests, or a promotion service.
+The artifact handoff strategy is documented in
+[`docs/artifact-handoff-strategy.md`](artifact-handoff-strategy.md). It keeps
+`docker/prod/runtime` as the first local backend while requiring API, Airflow,
+and runner consumers to use promoted manifests instead of implicit file
+conventions.
 
 ## Runtime identities and exceptions
 

--- a/docs/ports-and-services.md
+++ b/docs/ports-and-services.md
@@ -95,6 +95,12 @@ The following service families are intentionally not published on host ports:
 | MinIO API and console | Prod-like | Internal artifact backend; host UI kept dev-only |
 | Prometheus, Pushgateway, Alertmanager, cAdvisor, MailHog | Prod-like | Internal support services; host UI kept dev-only except Grafana |
 
+The hybrid artifact handoff strategy is documented in
+[`docs/artifact-handoff-strategy.md`](artifact-handoff-strategy.md). In the
+production-like runtime, MinIO can be referenced by optional `s3://` object URIs
+inside promoted manifests without publishing MinIO API or console ports to the
+host.
+
 `airflow-redis` used to publish `6379` on the host. It is now internal-only
 because no documented local workflow requires direct host access to the broker.
 

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -10,6 +10,7 @@ development and local production-like validation.
 - Keep deployment-specific Airflow DAGs close to their runtime assets.
 - Treat root `data`, `logs`, and `models` as development and DVC workspaces.
 - Treat `docker/prod/runtime` as an ignored production-like runtime workspace.
+- Use promoted artifact manifests as the runtime handoff contract.
 - Keep local environment files out of Git.
 - Keep dev and prod Compose files structurally comparable.
 
@@ -51,6 +52,7 @@ development and local production-like validation.
 | `docker/dev/` | Yes | No | Partly | No | No | No |
 | `docker/prod/` | Yes | No | Partly | No | No | No |
 | `docker/prod/runtime/` | No | Yes | Yes | No | Yes | No |
+| `docker/prod/runtime/artifacts/` | No | Yes | Yes | No | Yes | No |
 | `docker/common/` | Optional | No | Optional | No | No | No |
 | `docs/` | Yes | No | No | No | No | No |
 | `data/raw/` | Metadata or placeholders | Restored locally | Yes | Yes | Partly | No |
@@ -107,6 +109,11 @@ It writes generated operational data under `docker/prod/runtime`, which is
 ignored by Git and not DVC-managed. The only current root data dependency is the
 required source CSV mounted read-only from `data/raw` into the ingestion service.
 
+Runtime artifact promotion is defined by
+[`docs/artifact-handoff-strategy.md`](artifact-handoff-strategy.md). Consumers in
+`docker/prod` should use promoted manifests rather than scanning runtime folders
+for the newest files.
+
 ### `docker/common`
 
 `docker/common` may be introduced only when dev and prod runtimes share enough
@@ -119,6 +126,7 @@ runtime-specific clarity is preferable to premature abstraction.
 | ---------------- | -------------- |
 | `docs/repository-structure.md` | Repository paths, runtime ownership, artifacts, and dev/prod split. |
 | `docs/local-prod-runtime.md` | Dev/prod Compose operation model and local-prod constraints. |
+| `docs/artifact-handoff-strategy.md` | Manifest-first artifact promotion and local/object storage handoff contract. |
 | `docs/runtime-communication-matrix.md` | Current service-to-service communication and mount coupling. |
 | `docs/runtime-security-boundaries.md` | Runtime identities and boundary design for Phase 6 and Phase 7. |
 | `docs/local-prod-network-topology.md` | Target local production-like network topology. |
@@ -154,13 +162,15 @@ Directory expectations:
 - `docker/prod/runtime/data`, `docker/prod/runtime/models`, and
   `docker/prod/runtime/logs` are production-like runtime outputs and are not
   DVC-managed.
+- `docker/prod/runtime/artifacts` is the expected local root for promoted
+  manifest files and artifact payloads in the first manifest-first runtime.
 - `.dvc/config` is versioned; `.dvc/config.local`, `.dvc/cache/`, and
   `.dvc/tmp/` are local-only.
 
 The development runtime intentionally mounts root `data`, `logs`, and `models`
 for local visibility. The local production-like runtime avoids writing to those
-root workspaces and uses `docker/prod/runtime` instead until a stronger artifact
-handoff contract is introduced.
+root workspaces and uses `docker/prod/runtime` plus promoted manifests instead of
+implicit filesystem discovery.
 
 ## Scripts and helper ownership
 
@@ -205,7 +215,8 @@ Follow-up work should use this sequence:
 2. Use `docker/prod` as the local production-like validation runtime.
 3. Keep root `data`, `logs`, and `models` dev/DVC-owned.
 4. Keep production-like generated outputs under `docker/prod/runtime`.
-5. Define artifact handoff before reducing remaining local runtime mounts.
+5. Use the artifact handoff contract before reducing remaining local runtime
+   mounts.
 6. Decide whether Airflow DAGs need separate dev and prod placement.
 7. Introduce `docker/common` only when concrete shared assets justify it.
 8. Update diagrams and operations docs after the target runtime is validated.


### PR DESCRIPTION
## Summary

Implements the design-only scope of #63 by documenting the hybrid artifact handoff contract used by the local production-like runtime.

## Changes

- Add `docs/artifact-handoff-strategy.md`.
- Define manifest-first promotion, lifecycle states, ownership, local backend paths, optional MinIO `s3://` URI conventions, identifiers, manifest shape, and promotion rules.
- Link the strategy from `README.md`, `docs/local-prod-runtime.md`, `docs/repository-structure.md`, and `docs/ports-and-services.md`.
- Explicitly keep implementation work out of scope for later Phase 8 stories.

## Validation

Documentation-only change. I reviewed the branch diff against `main` and confirmed it contains only documentation updates.

Closes #63