### PR TITLE
docs: consolidate post phase 7 documentation hierarchy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Project documentation index
+
+This folder is organized so contributors can distinguish current operating
+instructions, architecture references, and Phase 8 target designs.
+
+## Current runtime and operations
+
+Use these documents to run or validate what exists on `main` now.
+
+| Document | Purpose |
+| -------- | ------- |
+| [`local-prod-runtime.md`](local-prod-runtime.md) | Current `docker/dev` and `docker/prod` runtime guide, workspace ownership, remaining exceptions, and validation entrypoints. |
+| [`ports-and-services.md`](ports-and-services.md) | Host-exposed ports, local URLs, and internal-only services for dev and production-like runtimes. |
+| [`dependency-strategy.md`](dependency-strategy.md) | uv groups, custom images, upstream runtime images, healthchecks, and dependency upgrade policy. |
+| [`repository-structure.md`](repository-structure.md) | Repository ownership rules, generated artifact expectations, DVC boundaries, and dev/prod runtime placement. |
+
+## Architecture references
+
+Use these documents to understand the current local MLOps architecture and the
+rules that should guide future runtime changes.
+
+| Document | Purpose |
+| -------- | ------- |
+| [`runtime-communication-matrix.md`](runtime-communication-matrix.md) | Service-to-service communication, mount coupling, and Phase 8 additions. |
+| [`runtime-security-boundaries.md`](runtime-security-boundaries.md) | Runtime identities, Docker socket boundary, host exposure, and security hardening direction. |
+| [`local-prod-network-topology.md`](local-prod-network-topology.md) | Implemented `docker/prod` functional network topology and rules for future service placement. |
+
+## Phase 8 target designs
+
+Use these documents when implementing Phase 8 stories.
+
+| Document | Purpose |
+| -------- | ------- |
+| [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md) | Hybrid manifest-first artifact promotion contract using local runtime paths and optional MinIO object URIs. |
+| [`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md) | Target runner-based Airflow execution model that replaces DockerOperator in `docker/prod`. |
+
+## Reading order
+
+For runtime work, read:
+
+1. [`local-prod-runtime.md`](local-prod-runtime.md)
+2. [`repository-structure.md`](repository-structure.md)
+3. [`runtime-communication-matrix.md`](runtime-communication-matrix.md)
+4. [`runtime-security-boundaries.md`](runtime-security-boundaries.md)
+
+For Phase 8 implementation, read:
+
+1. [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md)
+2. [`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md)
+3. [`local-prod-network-topology.md`](local-prod-network-topology.md)
+4. The issue body for the current Phase 8 story.
+
+## Documentation rules
+
+- Keep the root `README.md` concise and project-oriented.
+- Put operational runtime details in `local-prod-runtime.md`.
+- Put host port inventories in `ports-and-services.md`.
+- Put implementation roadmap details in Phase 8 story issues, not in the root
+  README.
+- When a target design becomes implemented, move its wording from future tense to
+  current-state wording and keep only the remaining gaps in a dedicated section.

--- a/docs/airflow-job-runner-strategy.md
+++ b/docs/airflow-job-runner-strategy.md
@@ -1,12 +1,15 @@
 # Airflow job runner strategy
 
-This document is the Phase 7 design artifact for issue #56. It defines a
-safer local production-like model for Airflow-triggered ML jobs without
-implementing the worker pool yet.
+This document is the Phase 8 target design for replacing DockerOperator-based ML
+execution in the local production-like runtime.
 
-The current `docker/dev` runtime is intentionally unchanged by this story.
-The target described here should feed a future `docker/prod` or
-`docker/local-prod` implementation.
+Phase 7 already introduced the `docker/prod` runtime, functional networks, and a
+production-like Airflow worker without `/var/run/docker.sock`. Phase 8 uses this
+document to implement the remaining runner-based execution path.
+
+`docker/dev` intentionally keeps the DockerOperator workflow because it remains
+useful for local debugging and broad host visibility. `docker/prod` should use a
+narrow job submission interface instead of container-runtime access.
 
 ## Scope and inputs
 
@@ -14,155 +17,150 @@ The design uses these project inputs:
 
 | Source | Use in this design |
 | ------ | ------------------ |
-| `docker-compose.yaml` | Current Airflow, ML, MLflow, API, monitoring, network, user, and mount model. |
-| `docs/runtime-communication-matrix.md` | Current Docker socket execution path, service-name traffic, shared mounts, and local-only boundaries. |
+| `docs/README.md` | Documentation hierarchy and reading order. |
+| `docs/local-prod-runtime.md` | Current dev/prod runtime split and known production-like gaps. |
+| `docs/runtime-communication-matrix.md` | Current Docker socket execution path, service traffic, and Phase 8 additions. |
 | `docs/runtime-security-boundaries.md` | Runtime identities, Docker socket risk, non-root targets, and job execution boundary. |
-| `docs/local-prod-network-topology.md` | Target functional networks and the `pipeline_runtime_net` boundary. |
-| `docs/repository-structure.md` | DAG placement rules and the current `docker/dev` versus future `docker/prod` split. |
-| `docker/dev/airflow/config/variables.json` | Current Docker image names, Docker network, MLflow, MinIO, Pushgateway, UID, and GID variables. |
+| `docs/local-prod-network-topology.md` | Implemented functional networks and the `pipeline_runtime_net` boundary. |
+| `docs/artifact-handoff-strategy.md` | Manifest-first artifact handoff contract used by runner outputs. |
+| `docs/repository-structure.md` | DAG placement rules and the `docker/dev` versus `docker/prod` split. |
+| `docker/dev/airflow/config/variables.json` | Current dev Docker image names, network, MLflow, MinIO, Pushgateway, UID, and GID variables. |
 | `docker/dev/airflow/config/connections.json` | Current Airflow HTTP connection to `api-dev`. |
 | `docker/dev/airflow/scripts/airflow-init.sh` | Current Airflow variable, connection, and pool bootstrap flow. |
-| `docker/dev/airflow/scripts/airflow-entrypoint.sh` | Current root entrypoint used to adjust Docker socket group access. |
+| `docker/dev/airflow/scripts/airflow-entrypoint.sh` | Current root entrypoint used to adjust Docker socket group access in dev. |
 | `docker/dev/airflow/config/bike_dag_config.json` | Multi-counter init and daily DAG business configuration. |
 
-This story is design-only. It does not implement the runner, rewrite DAGs,
-remove the Docker socket from `docker/dev`, add Kubernetes, or introduce
-production secrets.
+This document does not implement the runner, rewrite DAGs, remove the Docker
+socket from `docker/dev`, add Kubernetes, or introduce production secrets.
+
+## Current status
+
+Implemented after Phase 7:
+
+- `docker/prod` exists as a local production-like runtime.
+- `docker/prod` uses functional networks instead of `mlops_net`.
+- `docker/prod` Airflow services do not mount `/var/run/docker.sock`.
+- Custom prod-like API and ML images run as non-root users.
+- Root `data`, `models`, and `logs` remain development/DVC workspaces.
+- Production-like generated outputs use `docker/prod/runtime`.
+
+Remaining Phase 8 work:
+
+- typed pipeline job contracts;
+- internal `job-runner-api`;
+- runner execution path;
+- production-like Airflow DAG variant using the runner;
+- artifact-aware API serving;
+- production-like smoke validation.
 
 ## Decision summary
 
-The preferred local production-like target is a controlled internal job
-runner composed of:
+The preferred local production-like target is a controlled internal job runner
+composed of:
 
 1. a small internal job API;
-2. a dedicated queue and job state store;
-3. pre-started non-root typed ML worker services;
-4. an allow-list of supported job commands;
+2. a simple job state model;
+3. typed ML worker execution paths;
+4. an allow-list of supported job types and arguments;
 5. explicit artifact handoff and observability contracts.
 
-Airflow should submit and observe jobs. It should not create containers
-through the host Docker socket in the production-like runtime.
+Airflow should submit and observe jobs. It should not create containers through
+the host Docker socket in the production-like runtime.
 
-This target combines the best properties of a queue-based runner and a
-pre-started worker pool while keeping the architecture translatable to
-Kubernetes Jobs or CronJobs later.
+This target keeps the architecture translatable to Kubernetes Jobs or CronJobs
+later without forcing Kubernetes into the local Compose runtime.
 
-Ingestion, feature engineering, and model training must remain separate
-business microservices. They may share a common runner protocol, common
-schemas, and a common base image pattern, but they should not be collapsed
-into a single generic ML service.
+Ingestion, feature engineering, and model training must remain separate business
+microservices. They may share a common runner protocol, common schemas, and a
+common base image pattern, but they should not be collapsed into a single generic
+ML service.
 
-## Current Airflow-triggered execution model
+## Current Airflow-triggered execution model in development
 
 The current local development model uses Airflow as both orchestrator and
 container launcher:
 
 1. Airflow imports variables and connections during `airflow-init`.
-2. DAG tasks read Docker image names, network names, MLflow endpoints,
-   MinIO credentials, Pushgateway address, and UID/GID values from Airflow
-   variables.
-3. The Airflow worker mounts `/var/run/docker.sock`.
-4. The Airflow worker starts ML containers for ingestion, feature engineering,
-   training, and prediction.
+2. DAG tasks read Docker image names, network names, MLflow endpoints, MinIO
+   credentials, Pushgateway address, and UID/GID values from Airflow variables.
+3. The development Airflow worker mounts `/var/run/docker.sock`.
+4. The development Airflow worker starts ML containers for ingestion, feature
+   engineering, training, and prediction.
 5. ML containers read and write shared `data`, `logs`, and `models` paths.
-6. Model jobs log run evidence to MLflow and push batch metrics to
-   Pushgateway.
+6. Model jobs log run evidence to MLflow and push batch metrics to Pushgateway.
 7. Airflow calls the FastAPI admin refresh endpoint after successful runs.
 
-This model is practical for local development because it reuses existing
-Docker images and keeps artifacts visible on the host. It is not a
-production-like job boundary.
+This model is practical for local development because it reuses existing Docker
+images and keeps artifacts visible on the host. It is not a production-like job
+boundary and should remain dev-only.
 
 ## Why broad container-runtime access is not production-like
 
-A container with write access to the Docker socket can ask the host Docker
-daemon to create containers, mount host paths, join networks, and access
-data or secrets available to the daemon.
+A container with write access to the Docker socket can ask the host Docker daemon
+to create containers, mount host paths, join networks, and access data or secrets
+available to the daemon.
 
-The current `airflow-worker` therefore mixes two responsibilities:
+The development `airflow-worker` therefore mixes two responsibilities:
 
-- orchestration: schedule tasks, track dependencies, expose retries, and keep
-  DAG state;
-- execution control: create runtime containers with host-level Docker
-  privileges.
+- orchestration: schedule tasks, track dependencies, expose retries, and keep DAG
+  state;
+- execution control: create runtime containers with host-level Docker privileges.
 
 This coupling creates production-like concerns:
 
-| Concern | Current behavior | Target behavior |
-| ------- | ---------------- | --------------- |
+| Concern | Development behavior | Production-like target behavior |
+| ------- | -------------------- | ------------------------------- |
 | Privilege boundary | Airflow worker can control the host container runtime. | Airflow can call only a narrow job submission interface. |
 | Runtime user | Worker uses a root entrypoint to align Docker socket access. | Airflow and ML workers run without Docker socket access. |
 | Network scope | Jobs inherit networks selected by Airflow variables. | Jobs run on predefined functional networks. |
 | Command scope | DAG code can construct container commands. | Runner accepts only allow-listed job types and arguments. |
-| Artifact scope | Jobs write broad host-mounted folders. | Jobs publish through an explicit handoff contract. |
+| Artifact scope | Jobs write broad host-mounted folders. | Jobs publish through manifest-first artifact handoff. |
 | Observability | DockerOperator status is mixed with container logs. | Runner exposes job state, retries, logs, and metrics. |
 
 ## Workload model
 
 The runner must cover the existing ML pipeline shape:
 
-| Job type | Current image or action | Main outputs | External dependencies |
-| -------- | ----------------------- | ------------ | --------------------- |
-| `ingest` | `ml-ingest-dev` | interim data and ingest metrics | raw data, `data`, `logs`, Pushgateway |
-| `features` | `ml-features-dev` | processed features and feature metrics | interim data, `data`, `logs`, Pushgateway |
-| `models` | `ml-models-dev` | forecasts, model artifacts, MLflow runs | processed data, `data`, `models`, `logs`, MLflow, Pushgateway |
+| Job type | Current dev image or action | Main outputs | External dependencies |
+| -------- | --------------------------- | ------------ | --------------------- |
+| `ingest` | `ml-ingest-dev` | interim data and ingest metrics | raw data, runtime data workspace, logs, Pushgateway |
+| `features` | `ml-features-dev` | processed features and feature metrics | interim data, runtime data workspace, logs, Pushgateway |
+| `models` | `ml-models-dev` | forecasts, model artifacts, MLflow runs, prediction manifest | processed data, runtime data/model workspace, logs, MLflow, Pushgateway |
 | `api_refresh` | `api-dev` HTTP admin call | refreshed serving cache | FastAPI service and API credentials |
 
 The init and daily DAGs should keep their business responsibility: choose
 counters, derive ranges or dates, trigger jobs in the right order, and decide
-whether downstream refresh is allowed. They should stop owning container
-runtime details.
-
-The production-like runner should preserve the service boundaries already
-visible in the current batch images:
-
-- ingestion owns raw-to-interim import logic;
-- feature engineering owns interim-to-processed transformation logic;
-- model jobs own training, prediction, MLflow, and model artifact logic.
-
-Those boundaries are useful business boundaries, not only Docker packaging
-accidents. The future worker pool should make them more explicit instead of
-turning them into one generic worker with broad configuration and broad
-permissions.
-
-## Alternatives considered
-
-| Alternative | Benefits | Limitations | Decision |
-| ----------- | -------- | ----------- | -------- |
-| Pre-started typed non-root worker pool | Removes Docker socket from Airflow, keeps service boundaries explicit, makes users, mounts, networks, and resource sizing specific per ML stage. | Needs a common worker protocol, job leases, and status tracking. | Use as the selected worker target. |
-| Queue-based job runner | Decouples Airflow task lifetime from job execution, supports backpressure and retries, maps well to multiple counters. | Requires queue state, idempotency, and a polling or callback contract. | Use as part of the selected target. |
-| Controlled internal API or command runner | Gives Airflow one narrow interface, allows request validation, and hides execution internals. | API must not become a remote shell; commands and paths need strict allow-lists. | Use as the Airflow-facing entrypoint. |
-| Compose profile with long-lived workers | Fits local production-like Compose and avoids Kubernetes as a hard dependency. | Scaling is coarse and depends on Compose replicas or explicit services. | Use initially for `docker/prod` or `docker/local-prod`. |
-| Generic ML worker | One worker image containing ingestion, feature, and model entrypoints. | Blurs business boundaries, requires broader dependencies, broader credentials, and less specific health checks. | Do not use as the first target. |
-| Restricted container-runtime proxy | Smaller transition from DockerOperator and could enforce image or mount restrictions. | Still exposes container-runtime semantics and remains weaker than a true job boundary. | Keep only as a temporary fallback, not the target. |
-| Kubernetes Jobs or CronJobs | Stronger future fit for isolated batch jobs, service accounts, pod security, and retry policies. | Out of scope now and too large for the local Compose target. | Treat as future migration target. |
+whether downstream refresh is allowed. They should stop owning container runtime
+details.
 
 ## Selected target architecture
 
 ```mermaid
 flowchart LR
     airflow[Airflow DAG tasks] --> job_api[job-runner-api]
-    job_api --> queue[(job-runner-queue)]
-    queue --> worker_ingest[ml-ingest-worker]
-    queue --> worker_features[ml-features-worker]
-    queue --> worker_models[ml-models-worker]
+    job_api --> state[(job state)]
+    job_api --> worker_ingest[ingest execution]
+    job_api --> worker_features[features execution]
+    job_api --> worker_models[models execution]
 
-    worker_ingest --> data[(data or artifact handoff)]
-    worker_features --> data
-    worker_models --> data
+    worker_ingest --> artifacts[(artifact manifest store)]
+    worker_features --> artifacts
+    worker_models --> artifacts
     worker_models --> mlflow[mlflow-server]
     worker_ingest --> pushgateway[monitoring-pushgateway]
     worker_features --> pushgateway
     worker_models --> pushgateway
 
     airflow --> api[api-dev refresh]
+    api --> artifacts
     prometheus[monitoring-prometheus] --> job_api
     prometheus --> pushgateway
 ```
 
-The diagram is a target design, not a `docker/dev` implementation diff.
+The diagram is a target design. It should be implemented through Phase 8 stories,
+not treated as current `docker/prod` behavior.
 
-### Control plane
+## Runner API
 
 Airflow submits a typed job request to `job-runner-api`. The request includes:
 
@@ -175,59 +173,58 @@ Airflow submits a typed job request to `job-runner-api`. The request includes:
 - validated business parameters;
 - expected input and output artifact references.
 
-The API validates the request, assigns a `job_id`, writes a job record, and
-enqueues the job. Airflow receives `job_id` and observes the job until it
+The API validates the request, assigns a `job_id`, records job state, and starts
+or dispatches execution. Airflow receives `job_id` and observes the job until it
 reaches a terminal state.
 
-### Worker pool
+The first implementation can use in-memory state if it remains clear that this is
+a local production-like bridge, not a durable distributed queue.
 
-Workers are long-lived containers started by Compose. They consume jobs from
-the queue and execute only allow-listed commands.
+## Worker execution
 
-The first implementation target should use typed workers from the start:
+The first implementation target should use typed execution paths from the start:
 
-| Worker service | Accepted jobs | Service-specific constraints |
-| -------------- | ------------- | ---------------------------- |
-| `ml-ingest-worker` | `ingest` only | Raw and interim data access, ingest configuration, Pushgateway metrics. |
-| `ml-features-worker` | `features` only | Interim and processed data access, feature configuration, Pushgateway metrics. |
-| `ml-models-worker` | `models` only | Processed/final data, model artifacts, MLflow, MinIO/S3 credentials, Pushgateway metrics. |
+| Worker or execution path | Accepted jobs | Service-specific constraints |
+| ------------------------ | ------------- | ---------------------------- |
+| Ingestion execution | `ingest` only | Raw and interim data access, ingest configuration, Pushgateway metrics. |
+| Feature execution | `features` only | Interim and processed data access, feature configuration, Pushgateway metrics. |
+| Model execution | `models` only | Processed/final data, model artifacts, MLflow, optional MinIO/S3 credentials, Pushgateway metrics. |
 
-The three workers may share a common job protocol:
+The execution paths may share a common job protocol:
 
-- claim a queued job;
 - validate the job payload with a typed schema;
 - resolve a safe command from an allow-list;
 - execute the business entrypoint;
 - publish status, logs, metrics, and artifact references.
 
 They should not share one broad runtime configuration. Service-specific
-dependencies, environment variables, mounted paths, network attachments,
-health checks, and resource limits should remain explicit per worker service.
+dependencies, environment variables, mounted paths, network attachments, health
+checks, and resource limits should remain explicit per worker or per job type.
 
-### Job state model
+## Job state model
 
 The runner should expose a small state machine:
 
 | State | Meaning | Airflow behavior |
 | ----- | ------- | ---------------- |
-| `submitted` | Request was accepted and persisted. | Continue polling. |
-| `queued` | Job is waiting for a worker. | Continue polling or sensor deferral. |
-| `running` | Worker started the command. | Continue polling and link logs. |
+| `submitted` | Request was accepted and recorded. | Continue polling. |
+| `queued` | Job is waiting for execution. | Continue polling or sensor deferral. |
+| `running` | Execution started. | Continue polling and link logs. |
 | `succeeded` | Command exited successfully and outputs were published. | Mark task successful. |
 | `failed` | Command failed with a controlled error. | Fail the Airflow attempt. |
 | `canceled` | Job was canceled by operator or cleanup policy. | Fail or skip according to DAG policy. |
 | `expired` | Job exceeded retention or timeout. | Fail with an explicit timeout reason. |
 
 Airflow retries should create distinct external attempts by including
-`try_number` in the idempotency key. Re-submitting the same key should return
-the existing `job_id` instead of duplicating work.
+`try_number` in the idempotency key. Re-submitting the same key should return the
+existing `job_id` instead of duplicating work.
 
 ## Impact on Airflow DAGs
 
-The future DAG change should replace direct container creation with a narrow
-job client.
+The production-like DAG change should replace direct container creation with a
+narrow job client.
 
-Current DAG responsibility:
+Development DAG responsibility:
 
 - build container commands;
 - select Docker images and networks;
@@ -235,7 +232,7 @@ Current DAG responsibility:
 - wait for the container exit code;
 - call API refresh after successful jobs.
 
-Target DAG responsibility:
+Production-like DAG responsibility:
 
 - build typed business job specs;
 - submit jobs to `job-runner-api`;
@@ -244,11 +241,11 @@ Target DAG responsibility:
 - call API refresh through the existing HTTP connection;
 - preserve DAG-level retry, schedule, and dependency semantics.
 
-DAG code should stay near Airflow runtime assets under `docker/dev` or the
-future `docker/prod` Airflow area unless the project later decides to package
-DAGs as importable application modules. Reusable client or schema logic may
-live under `src/` with tests, but deployment-specific DAG wiring should remain
-close to the Airflow runtime that consumes it.
+DAG code should stay near Airflow runtime assets under `docker/dev` or
+`docker/prod` unless the project later decides to package DAGs as importable
+application modules. Reusable client or schema logic may live under `src/` with
+tests, but deployment-specific DAG wiring should remain close to the Airflow
+runtime that consumes it.
 
 ## Init and daily DAG trigger flow
 
@@ -258,8 +255,8 @@ close to the Airflow runtime that consumes it.
 2. For each configured counter, submit `ingest`.
 3. Submit `features` only after the matching ingest job succeeds.
 4. Submit `models` only after the matching feature job succeeds.
-5. Call the API refresh endpoint only when required model or forecast outputs
-   are promoted.
+5. Promote or refresh final prediction data only after required model outputs are
+   promoted.
 6. Fail the Airflow run if any required runner job fails.
 
 ### Daily DAG
@@ -268,220 +265,34 @@ close to the Airflow runtime that consumes it.
 2. Submit `ingest` with the daily range and counter configuration.
 3. Submit `features` and `models` with the same idempotency context.
 4. Promote or refresh final prediction data only after successful model jobs.
-5. Keep Airflow retries at the orchestration layer while the runner records
-   every external job attempt.
+5. Keep Airflow retries at the orchestration layer while the runner records every
+   external job attempt.
 
 In both flows, Airflow never asks Docker to start a container. It only asks the
 job runner to execute an allowed job type.
 
-## Container image impact
+## Phase 8 story mapping
 
-The future implementation should introduce typed worker images or typed worker
-service images:
+| Story | Role |
+| ----- | ---- |
+| #64 | Implement artifact manifest models used by job results. |
+| #65 | Implement manifest writer and promotion helpers. |
+| #66 | Make ML jobs emit artifact manifests. |
+| #67 | Implement typed pipeline job contracts. |
+| #68 | Add the internal `job-runner-api` skeleton. |
+| #69 | Execute typed ML jobs through the runner. |
+| #70 | Add the production-like Airflow DAG using the runner API. |
+| #71 | Make the API serve promoted artifacts from manifests. |
+| #72 | Add production-like smoke validation. |
+| #73 | Harden runtime configuration and secrets validation. |
 
-| Image or service image | Responsibility | Notes |
-| ---------------------- | -------------- | ----- |
-| `job-runner-api` | Validate job requests, expose job status, and enqueue work. | Small FastAPI service; internal-only; no Docker socket. |
-| `ml-ingest-worker` | Execute allow-listed ingestion jobs as a non-root service. | Derive from ingest code and dependencies; do not require MLflow or model credentials. |
-| `ml-features-worker` | Execute allow-listed feature engineering jobs as a non-root service. | Derive from feature code and dependencies; keep feature mounts and health checks specific. |
-| `ml-models-worker` | Execute allow-listed model jobs as a non-root service. | Derive from model code and dependencies; owns MLflow, MinIO/S3, and model artifact access. |
+## Validation target
 
-Existing `ml-ingest-dev`, `ml-features-dev`, and `ml-models-dev` images should
-remain valid for `docker/dev` while the local production-like runtime is built
-separately.
+A complete Phase 8 validation should eventually prove that:
 
-They should not be reused directly as long-running workers because they are
-currently batch CLI containers: they have a Python module entrypoint, a
-Compose-provided command, local bind mounts, and `restart: "no"` semantics. The
-future workers should reuse their business code, dependency lists, and Docker
-packaging patterns, but expose a worker lifecycle instead of a one-shot CLI
-lifecycle.
-
-A future implementation can choose between two safe packaging variants:
-
-1. derive three worker images from the current `ml-ingest`, `ml-features`, and
-   `ml-models` Dockerfiles, replacing the CLI entrypoint with a worker
-   process;
-2. factor common Docker layers into a shared base image while keeping three
-   final service images with distinct entrypoints, dependencies, networks,
-   volumes, environment variables, and health checks.
-
-The second variant reduces duplicated build layers without weakening the
-microservice boundary.
-
-## Network impact
-
-The target aligns with `docs/local-prod-network-topology.md`.
-
-| Component | Target networks | Reason |
-| --------- | --------------- | ------ |
-| Airflow worker or DAG execution service | `orchestration_net`, `pipeline_runtime_net` | Keep Airflow metadata access separate from job submission. |
-| `job-runner-api` | `pipeline_runtime_net`, `observability_net` | Receive Airflow job submissions and expose runner metrics. |
-| Job queue or state store | `pipeline_runtime_net` | Internal runner state only. |
-| `ml-ingest-worker` | `pipeline_runtime_net` | Read ingest jobs, write interim outputs, and push ingest metrics. |
-| `ml-features-worker` | `pipeline_runtime_net` | Read feature jobs, write processed outputs, and push feature metrics. |
-| `ml-models-worker` | `pipeline_runtime_net`, `tracking_client_net` | Read model jobs, log MLflow runs, and publish model outputs. |
-| `mlflow-server` | `tracking_client_net`, `tracking_backend_net` | Accept MLflow client calls without exposing backends broadly. |
-| `monitoring-pushgateway` | `pipeline_runtime_net`, `observability_net` | Receive batch metrics and expose scrape endpoint. |
-| `api-dev` | `pipeline_runtime_net`, `observability_net` | Receive refresh call and expose application metrics. |
-
-The runner should not join Airflow metadata networks unless it truly needs
-Airflow internals. The queue should not be the same Redis instance used by
-Airflow Celery unless a future design explicitly accepts that coupling.
-
-## User and permission impact
-
-Target permissions:
-
-- no Docker socket mount in Airflow or runner containers;
-- no root entrypoint for worker execution;
-- ML workers run as a non-root application user;
-- job API can enqueue and read job state but cannot execute arbitrary shell;
-- command arguments are validated against typed schemas and allow-lists;
-- writable paths are limited to approved data, log, model, or artifact
-  handoff locations;
-- credentials are scoped to the job type that needs them.
-
-The current `airflow-worker` root entrypoint is a local-development exception.
-The production-like runtime should remove this exception once the runner takes
-over ML execution.
-
-## Volume and artifact handoff impact
-
-Phase 1 can keep local bind mounts to reduce migration risk:
-
-| Path | Phase 1 behavior | Target concern |
-| ---- | ---------------- | -------------- |
-| `data/raw` | Read by ingest workers. | Read-only for workers except controlled import paths. |
-| `data/interim` | Written by ingest and read by feature jobs. | Explicit job output reference. |
-| `data/processed` | Written by feature jobs and read by model jobs. | Explicit job output reference. |
-| `data/final` | Written or promoted by model jobs and read by API. | Controlled release contract. |
-| `models` | Written by model jobs. | Prefer MLflow artifacts or model registry evidence. |
-| `logs` | Written by runner and workers. | Later move to remote or structured log storage. |
-
-Phase 2 should replace broad shared mounts with an explicit artifact handoff
-contract, such as object storage, release manifests, or a small promotion
-service. The runner should make artifact paths explicit in the job record so
-Airflow and operators can audit what each job produced.
-
-## Observability impact
-
-The runner should expose its own operational metrics and preserve existing ML
-job metrics.
-
-| Signal | Source | Target sink |
-| ------ | ------ | ----------- |
-| Job state | `job-runner-api` or state store | Airflow polling and runner API. |
-| Job duration | Runner and ML jobs | Prometheus through runner metrics or Pushgateway. |
-| Job records processed | ML job entrypoints | Existing Pushgateway flow. |
-| Model metrics and artifacts | Model worker | MLflow server. |
-| Logs | Runner and workers | Airflow task links initially; structured logs later. |
-| Queue depth | Queue or runner API | Prometheus scrape. |
-| Worker liveness | Worker heartbeat | Prometheus scrape or runner health endpoint. |
-
-Airflow should display the runner `job_id`, terminal state, and a log or
-status URL in task logs. A failed runner job should include the command type,
-counter ID, exit code, error category, and artifact references that were
-created before failure.
-
-## Retry and failure semantics
-
-Airflow remains the source of orchestration retries. The runner remains the
-source of external job execution truth.
-
-Recommended behavior:
-
-1. Airflow attempt submits a job with an idempotency key.
-2. Runner returns an existing job for duplicate submissions with the same key.
-3. Runner records worker start time, end time, exit code, and failure category.
-4. Airflow maps `failed`, `expired`, or `canceled` to task failure.
-5. Airflow retry creates a new attempt key with a new `try_number`.
-6. Runner retention keeps job metadata long enough for Airflow log inspection.
-
-The runner should avoid hidden internal retries for ML commands at first.
-Retrying in both Airflow and the runner would make failure analysis harder.
-Internal runner retries can be added later only for clearly transient runner
-infrastructure failures.
-
-## Security guardrails for the future implementation
-
-The first implementation story should include these guardrails:
-
-- typed Pydantic schemas for job submission and status responses;
-- an explicit allow-list for `ingest`, `features`, `models`, and `api_refresh`;
-- no free-form command or shell field in the API;
-- internal-only network exposure for the runner API;
-- request authentication suitable for local production-like Compose;
-- per-job environment variable allow-lists;
-- path normalization to prevent writes outside approved artifact roots;
-- bounded queue retention and log retention;
-- typed worker health checks for queue, volumes, and required endpoints;
-- unit tests for schema validation and command resolution;
-- integration smoke tests before removing Docker socket usage from the target
-  runtime.
-
-## Migration sequence
-
-1. Keep `docker/dev` unchanged and keep DockerOperator-based DAGs operational.
-2. Add runner schemas and a job client under `src/` with unit tests.
-3. Add a local production-like runner API and typed ML worker images.
-4. Add a separate Compose profile or `docker/prod` entrypoint for the runner.
-5. Implement runner health, metrics, job status, and log references.
-6. Add a target Airflow DAG variant that submits runner jobs instead of Docker
-   containers.
-7. Validate init and daily DAGs through the runner in the new runtime.
-8. Remove Docker socket access only from the production-like Airflow worker.
-9. Keep the current `docker/dev` path until the replacement is stable.
-10. Update architecture diagrams and operator documentation after validation.
-
-## Rollback criteria
-
-Keep or return to the current DockerOperator execution path if any of these
-conditions occur during a future implementation:
-
-- Airflow cannot submit jobs or recover job state after scheduler restart;
-- job status is not idempotent across Airflow retries;
-- ML workers cannot read required inputs or publish expected outputs;
-- model jobs cannot log to MLflow;
-- batch metrics no longer reach Pushgateway;
-- API refresh cannot be triggered after successful jobs;
-- operator logs become less actionable than current Airflow task logs;
-- `make compose-config` or target Compose validation fails.
-
-## Validation
-
-This story is documentation-only. Expected validation remains:
-
-```bash
-make compose-config
-```
-
-Future implementation stories should add validation such as:
-
-```bash
-docker compose --profile local-prod config
-docker compose --profile local-prod up -d \
-    job-runner-api \
-    ml-ingest-worker \
-    ml-features-worker \
-    ml-models-worker
-docker compose exec airflow-worker getent hosts job-runner-api
-docker compose exec job-runner-api wget -qO- http://localhost:8080/health
-docker compose exec ml-ingest-worker wget -qO- http://localhost:8080/health
-docker compose exec ml-features-worker wget -qO- http://localhost:8080/health
-docker compose exec ml-models-worker wget -qO- http://localhost:8080/health
-docker compose exec monitoring-prometheus \
-    wget -qO- http://job-runner-api:8080/metrics
-```
-
-## Out-of-scope items
-
-This design does not:
-
-- implement the worker pool;
-- rewrite existing DAGs;
-- remove Docker socket access from `docker/dev`;
-- add Kubernetes;
-- implement production secrets;
-- replace shared mounts;
-- change current `docker/dev` ML images or Compose services.
+- `docker/prod` Airflow has no Docker socket mount;
+- Airflow can submit a typed job to `job-runner-api`;
+- the runner can execute the pipeline or a representative pipeline subset;
+- successful execution publishes a valid manifest;
+- the API can report the promoted artifact;
+- monitoring can scrape relevant API and runner metrics.

--- a/docs/local-prod-network-topology.md
+++ b/docs/local-prod-network-topology.md
@@ -1,329 +1,169 @@
 # Local production-like network topology
 
-This document is the Phase 7 design artifact for issue #55. It derives a
-target local production-like Docker Compose topology from the current
-service-name dependencies.
+This document describes the implemented `docker/prod` functional network
+topology after Phase 7. It started as the Phase 7 design artifact for issue #55
+and now acts as the reference for current production-like Compose service
+placement and for Phase 8 service additions.
 
-The current `docker/dev` runtime is intentionally unchanged by this story. The
-target network set below is a proposal for a future `docker/prod` or
-`docker/local-prod` Compose implementation.
+`docker/dev` intentionally keeps its broader development-oriented network model.
+`docker/prod` uses bounded functional domains instead of the broad development
+`mlops_net`.
 
-## Scope and inputs
+## Documentation role
 
-The design reviews these runtime sources:
-
-| Source | Use in this design |
-| ------ | ------------------ |
-| `docker-compose.yaml` | Current services, networks, mounts, and host exposure. |
-| `.env.template` | Runtime names, ports, credentials, and local defaults. |
-| `docs/runtime-communication-matrix.md` | Current service traffic and host exposure. |
-| `docs/runtime-security-boundaries.md` | Runtime identities and boundary intent. |
-| `docs/repository-structure.md` | `docker/dev` stability and future `docker/prod` split. |
-| `docs/ports-and-services.md` | Host URLs and internal-only service ports. |
-| `docker/dev/prometheus/prometheus.yml` | Prometheus scrape and alert routing targets. |
-| `docker/dev/grafana/provisioning/datasources/datasource.yaml` | Grafana to Prometheus service-name dependency. |
-| `docker/dev/airflow/config/connections.json` | Airflow `api_dev` HTTP target. |
-| `docker/dev/airflow/config/variables.json` | DockerOperator images, network, MLflow, MinIO, and Pushgateway values. |
-
-The goal is network design only. It does not implement secrets, ingress,
-Kubernetes, worker execution replacement, or a Compose refactor.
+| Document | Role |
+| -------- | ---- |
+| [`local-prod-runtime.md`](local-prod-runtime.md) | Operational runtime guide and workspace ownership. |
+| [`runtime-communication-matrix.md`](runtime-communication-matrix.md) | Current service traffic and Phase 8 additions. |
+| [`runtime-security-boundaries.md`](runtime-security-boundaries.md) | Runtime identities and security boundaries. |
+| [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md) | Phase 8 artifact handoff contract. |
+| [`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md) | Phase 8 runner execution target. |
 
 ## Design principle
 
-The target model does not create one network per service pair. It uses bounded
-functional domains and allows a few edge services to join several domains when
-they are explicit gateways.
+The production-like runtime does not create one network per service pair. It uses
+bounded functional domains and allows a few edge services to join several domains
+when they are explicit gateways.
 
-A new network is justified only when at least one of these statements is true:
+A network is justified when at least one of these statements is true:
 
 - it protects stateful backend services such as PostgreSQL, Redis, or MinIO;
 - it represents a stable many-to-one communication pattern such as monitoring;
 - it separates local-development support services from production-like runtime
   services;
-- it carries privileged job-execution concerns such as Docker socket access or a
-  future job runner.
+- it carries privileged or controlled job-execution concerns such as the future
+  runner API and typed workers.
 
-Small two-service links should be avoided unless they protect sensitive state or
-privileged control surfaces. The target topology should remain readable with a
-small number of networks.
+## Implemented `docker/prod` networks
 
-## Current network review
-
-### `airflow_net`
-
-`airflow_net` is the Airflow control-plane network. It correctly groups the
-Airflow API server, scheduler, DAG processor, triggerer, worker, Flower,
-Airflow PostgreSQL, Redis, initialization task, and Airflow-managed jobs.
-
-Target decision:
-
-- keep Airflow metadata and broker services internal to an orchestration
-  boundary;
-- keep Airflow UI/API access as an explicit host or ingress concern, not a
-  shared platform network concern;
-- remove broad Airflow-to-platform attachment in the target model unless a
-  documented DAG dependency needs it;
-- treat `airflow-worker` Docker socket access as a local-dev exception until a
-  worker-pool or job-runner story replaces it.
-
-`api-dev` does not need to share the Airflow metadata network only to receive
-`POST /admin/refresh`. That call should use the standard API authentication over
-an internal Compose runtime network, resolving `api-dev:10000` through Docker
-service DNS. The host-published API port remains a local operator ingress and
-should not be the default container-to-container path.
-
-### `mlflow_net`
-
-`mlflow_net` is the ML tracking and artifact boundary. It correctly groups
-`mlflow-server`, `mlflow-postgres`, `mlflow-minio`, the MinIO bootstrap helper,
-and ML workloads that log tracking data or artifacts.
-
-Target decision:
-
-- keep `mlflow-postgres` private to tracking backend services;
-- keep `mlflow-minio` private to tracking/artifact services by default;
-- attach ML workloads through an explicit tracking client boundary;
-- avoid exposing tracking backend services on a broad integration network;
-- expose local MLflow and MinIO UIs only through deliberate local host or dev
-  ingress paths.
-
-A split between tracking clients and tracking backends is justified because ML
-jobs need `mlflow-server`, but they do not need direct PostgreSQL access.
-
-### `mlops_net`
-
-`mlops_net` is currently a broad local integration network. It is useful for
-development because it groups API, monitoring, Pushgateway, MailHog, cAdvisor,
-and selected cross-stack services.
-
-Target decision:
-
-- do not keep `mlops_net` as a broad local production-like network;
-- replace it with a small set of functional domains rather than many pairwise
-  links;
-- keep the name only as a legacy `docker/dev` concept, or rename it to
-  `dev_integration_net` if a future cleanup wants to make its purpose explicit;
-- do not migrate the name into `docker/prod` unless it is narrowed to a single
-  responsibility.
-
-## Proposed network set
-
-The recommended target uses five core networks and one optional future boundary.
-This keeps the Compose model bounded while still removing the broad `mlops_net`
-behavior.
-
-| Network | Responsibility | Expected members |
-| ------- | -------------- | ---------------- |
-| `orchestration_net` | Airflow control plane, metadata DB, broker, and internal Airflow execution API. | Airflow API, scheduler, DAG processor, triggerer, worker, init, Flower, PostgreSQL, Redis. |
-| `pipeline_runtime_net` | Runtime control and data-pipeline handoff between orchestration, API refresh, batch jobs, and batch metric writes. | Airflow worker or future job runner, `api-dev`, `ml-ingest-*`, `ml-features-*`, `ml-models-*`, `monitoring-pushgateway`. |
+| Network | Responsibility | Current members or expected members |
+| ------- | -------------- | ----------------------------------- |
+| `orchestration_net` | Airflow control plane, metadata DB, broker, and internal Airflow execution API. | Airflow API, scheduler, DAG processor, triggerer, worker, init, PostgreSQL, Redis. |
+| `pipeline_runtime_net` | Runtime control and data-pipeline handoff between orchestration, API refresh, batch jobs, and batch metric writes. | Airflow worker, API, ML jobs, Pushgateway, future `job-runner-api`. |
 | `tracking_client_net` | MLflow client API calls from ML workloads. | ML jobs and `mlflow-server`. |
 | `tracking_backend_net` | Private MLflow metadata and artifact backends. | `mlflow-server`, `mlflow-postgres`, `mlflow-minio`, `mlflow-mc-init`. |
-| `observability_net` | Monitoring, dashboard, alert-routing, and scrape access to selected metric endpoints. | Prometheus, Grafana, Alertmanager, cAdvisor, Pushgateway, API metrics endpoint, selected exporters. |
-| `dev_support_net` | Local development support services that should not be part of the production-like core. | MailHog, Airflow services that send local email, Alertmanager in local email mode. |
-| `artifact_handoff_net` | Optional future object-store or release handoff boundary if host bind mounts are replaced. | API, ML jobs, Airflow promotion step, and storage service when implemented. |
+| `observability_net` | Monitoring, dashboard, alert routing, and scrape access to selected metric endpoints. | Prometheus, Grafana, Alertmanager, cAdvisor, Pushgateway, API metrics endpoint, selected exporters. |
+| `dev_support_net` | Local support services that should not be part of the production-like core. | MailHog, Airflow services that send local email, Alertmanager in local email mode. |
 
-`artifact_handoff_net` should not be created only for the current host bind
-mounts. It becomes useful if a future story replaces broad `data`, `models`, or
-`logs` mounts with an object store or an explicit release service.
+`artifact_handoff_net` is not implemented. The current Phase 8 handoff strategy
+uses manifests that reference local runtime paths and optional MinIO object URIs.
+Introduce a dedicated artifact network only if a future object-store or promotion
+service needs a separate boundary.
 
 ## Gateway services
 
 A few services deliberately join multiple networks. These services are not
 accidental broad-network members; they bridge bounded domains.
 
-| Service | Target networks | Gateway role |
-| ------- | --------------- | ------------ |
-| `airflow-worker` or future job runner | `orchestration_net`, `pipeline_runtime_net`, optional `dev_support_net` | Runs or triggers jobs, calls API refresh, and remains connected to the Airflow control plane. |
-| `api-dev` | `pipeline_runtime_net`, `observability_net`, optional ingress or host port | Receives authenticated refresh calls and exposes metrics. Host publication remains local ingress, not the container-to-container path. |
-| `mlflow-server` | `tracking_client_net`, `tracking_backend_net` | Accepts MLflow client calls and owns backend access to PostgreSQL and MinIO. |
+| Service | Networks | Gateway role |
+| ------- | -------- | ------------ |
+| `airflow-worker` | `orchestration_net`, `pipeline_runtime_net`, `dev_support_net` | Runs orchestration tasks and, after Phase 8, submits work to the runner API. |
+| future `job-runner-api` | `pipeline_runtime_net`, optional `observability_net` | Accepts typed job submissions and exposes runner health/metrics internally. |
+| future typed ML workers | `pipeline_runtime_net`, plus `tracking_client_net` for model workers | Execute allowed business jobs without exposing Docker runtime control to Airflow. |
+| `api-dev` | `pipeline_runtime_net`, `observability_net` | Receives refresh calls and exposes metrics. Host publication remains local ingress. |
+| `mlflow-server` | `tracking_client_net`, `tracking_backend_net`, `observability_net` | Accepts MLflow client calls and owns backend access to PostgreSQL and MinIO. |
 | `monitoring-pushgateway` | `pipeline_runtime_net`, `observability_net` | Receives batch metrics writes and exposes them for Prometheus scrape. |
 | `monitoring-alertmanager` | `observability_net`, `dev_support_net` | Receives Prometheus alerts and sends local development email. |
 
-This gateway pattern is the replacement for `mlops_net`: cross-domain access is
-explicit and attached only to services that need it.
+This gateway pattern replaces `mlops_net` in the production-like runtime:
+cross-domain access is explicit and attached only to services that need it.
+
+## Current dev network review
+
+The development runtime still uses:
+
+| Network | Role in `docker/dev` |
+| ------- | -------------------- |
+| `airflow_net` | Airflow control plane plus DockerOperator execution context. |
+| `mlflow_net` | MLflow tracking and artifact plane. |
+| `mlops_net` | Broad local integration network for API, monitoring, Pushgateway, MailHog, cAdvisor, and cross-stack development access. |
+
+This model remains valid for development because it supports broad host
+visibility, DockerOperator jobs, and local debugging. It should not be copied
+into `docker/prod`.
 
 ## Required service-name dependencies
 
-| Source service | Target service | DNS name | Port | Protocol | Reason | Proposed network |
-| -------------- | -------------- | -------- | ---- | -------- | ------ | ---------------- |
-| `monitoring-prometheus` | `monitoring-prometheus` | `monitoring-prometheus` | `9090` | HTTP | Self scrape and readiness checks. | `observability_net` |
-| `monitoring-prometheus` | `monitoring-cadvisor` | `monitoring-cadvisor` | `8080` | HTTP | Container metric scrape. | `observability_net` |
-| `monitoring-prometheus` | `api-dev` | `api-dev` | `10000` | HTTP | FastAPI `/metrics` scrape. | `observability_net` |
-| `monitoring-prometheus` | `monitoring-pushgateway` | `monitoring-pushgateway` | `9091` | HTTP | Batch metric scrape. | `observability_net` |
-| `monitoring-prometheus` | `monitoring-alertmanager` | `monitoring-alertmanager` | `9093` | HTTP | Alert routing target. | `observability_net` |
-| `monitoring-grafana` | `monitoring-prometheus` | `monitoring-prometheus` | `9090` | HTTP | Provisioned datasource. | `observability_net` |
-| `monitoring-alertmanager` | `monitoring-mailhog` | `monitoring-mailhog` | `1025` | SMTP | Local alert email test route. | `dev_support_net` |
-| Airflow services | `airflow-postgres` | `airflow-postgres` | `5432` | PostgreSQL | Airflow metadata DB and result backend. | `orchestration_net` |
-| Airflow services | `airflow-redis` | `airflow-redis` | `6379` | Redis | Celery broker. | `orchestration_net` |
-| Airflow services | `airflow-api-server` | `airflow-api-server` | `8080` | HTTP | Internal Airflow execution API. | `orchestration_net` |
-| Airflow DAG tasks | `api-dev` | `api-dev` | `10000` | HTTP | Authenticated API refresh after successful DAG runs. | `pipeline_runtime_net` |
-| Airflow DAG tasks | ML job containers | Docker API | N/A | Docker API | Create ingestion, features, and model jobs. | `pipeline_runtime_net` |
-| Airflow services | `monitoring-mailhog` | `monitoring-mailhog` | `1025` | SMTP | Local Airflow email capture. | `dev_support_net` |
-| ML jobs | `monitoring-pushgateway` | `monitoring-pushgateway` | `9091` | HTTP | Push batch job metrics. | `pipeline_runtime_net` |
-| ML jobs | `mlflow-server` | `mlflow-server` | `5000` | HTTP | Log runs, metrics, params, and artifacts. | `tracking_client_net` |
-| `mlflow-server` | `mlflow-postgres` | `mlflow-postgres` | `5432` | PostgreSQL | MLflow backend store. | `tracking_backend_net` |
-| `mlflow-server` | `mlflow-minio` | `mlflow-minio` | `9000` | HTTP/S3 | MLflow artifact store. | `tracking_backend_net` |
-| `mlflow-mc-init` | `mlflow-minio` | `mlflow-minio` | `9000` | HTTP/S3 | Bootstrap the MLflow bucket. | `tracking_backend_net` |
-| API and ML jobs | promoted datasets | No DNS | N/A | Filesystem or S3 | Read/write released prediction artifacts. | Optional `artifact_handoff_net` |
+| Source service | Target service | DNS name | Port | Network | Reason |
+| -------------- | -------------- | -------- | ---- | ------- | ------ |
+| `monitoring-prometheus` | `api-dev` | `api-dev` | `10000` | `observability_net` | FastAPI `/metrics` scrape. |
+| `monitoring-prometheus` | `monitoring-cadvisor` | `monitoring-cadvisor` | `8080` | `observability_net` | Container metric scrape. |
+| `monitoring-prometheus` | `monitoring-pushgateway` | `monitoring-pushgateway` | `9091` | `observability_net` | Batch metric scrape. |
+| `monitoring-grafana` | `monitoring-prometheus` | `monitoring-prometheus` | `9090` | `observability_net` | Provisioned datasource. |
+| `monitoring-alertmanager` | `monitoring-mailhog` | `monitoring-mailhog` | `1025` | `dev_support_net` | Local alert email capture. |
+| Airflow services | `airflow-postgres` | `airflow-postgres` | `5432` | `orchestration_net` | Airflow metadata DB and result backend. |
+| Airflow services | `airflow-redis` | `airflow-redis` | `6379` | `orchestration_net` | Celery broker. |
+| Airflow services | `airflow-api-server` | `airflow-api-server` | `8080` | `orchestration_net` | Internal Airflow execution API. |
+| Airflow DAG tasks | `api-dev` | `api-dev` | `10000` | `pipeline_runtime_net` | Authenticated API refresh after successful DAG runs. |
+| ML jobs | `monitoring-pushgateway` | `monitoring-pushgateway` | `9091` | `pipeline_runtime_net` | Push batch job metrics. |
+| ML jobs | `mlflow-server` | `mlflow-server` | `5000` | `tracking_client_net` | Log runs, metrics, params, and artifacts. |
+| `mlflow-server` | `mlflow-postgres` | `mlflow-postgres` | `5432` | `tracking_backend_net` | MLflow backend store. |
+| `mlflow-server` | `mlflow-minio` | `mlflow-minio` | `9000` | `tracking_backend_net` | MLflow artifact store. |
+| `mlflow-mc-init` | `mlflow-minio` | `mlflow-minio` | `9000` | `tracking_backend_net` | Bootstrap the MLflow bucket. |
 
-The Docker API entry is a logical dependency. It is not a Compose DNS
-dependency, but it must stay visible in the migration plan because the current
-Airflow worker creates ML workload containers through the local Docker socket.
+## Phase 8 additions
 
-## Why monitoring uses one observability boundary
+Phase 8 should place new services according to these rules:
 
-Prometheus is intentionally a many-to-one scraper. Its checked-in configuration
-uses service names for several targets, and future exporters will likely follow
-the same pattern.
-
-A pairwise network per Prometheus target would create operational noise:
-
-- every new exporter would require a new Compose network;
-- Prometheus would need one extra attachment per target;
-- target removals would require network lifecycle cleanup;
-- dashboard and alert validation would become harder to reason about.
-
-A shared `observability_net` is the better local production-like boundary when
-it is limited to scrape endpoints, dashboard queries, alert routing, and selected
-exporters. It keeps service discovery maintainable while avoiding broad
-application, database, broker, and artifact-store colocation.
-
-`monitoring-pushgateway` is the main bridge between `pipeline_runtime_net` and
-`observability_net`: jobs write metrics on the pipeline side, and Prometheus
-scrapes metrics on the observability side.
-
-## Pairwise network policy
-
-The target design avoids pairwise networks by default. A pairwise network is
-justified only when the target contains sensitive backend state or a privileged
-runtime surface.
-
-Current strong candidates for narrow isolation are:
-
-- Airflow metadata DB and Redis inside `orchestration_net`;
-- MLflow PostgreSQL and MinIO inside `tracking_backend_net`;
-- Docker socket or replacement job runner access inside `pipeline_runtime_net`;
-- local SMTP capture isolated in `dev_support_net`.
-
-Monitoring does not qualify for pairwise links in this design because it has a
-stable many-target scrape pattern.
+- `job-runner-api` belongs on `pipeline_runtime_net` and should not be published
+  to the host by default.
+- Runner health or metrics may be attached to `observability_net` if Prometheus
+  needs to scrape them.
+- Typed ML workers should attach only to the networks required for their stage.
+- Model workers may attach to `tracking_client_net`; ingest and feature workers
+  should not receive MLflow or MinIO access unless they need it.
+- Artifact handoff should follow [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md)
+  before introducing any new network.
 
 ## Services that should not share a broad network
 
-The following services should not be colocated on a single broad network in a
-local production-like runtime:
+The following services should not be colocated on a single broad production-like
+network:
 
-- `airflow-postgres` and `airflow-redis` should not share a platform network
-  with API, Grafana, Prometheus, MLflow, or MailHog.
-- `mlflow-postgres` should not share a platform network with Airflow, API,
+- Airflow PostgreSQL and Redis should not share a platform network with API,
+  Grafana, Prometheus, MLflow, or MailHog.
+- MLflow PostgreSQL should not share a platform network with Airflow, API,
   monitoring, or local email services.
-- `mlflow-minio` should not share a broad network unless it becomes an explicit
-  project object-store boundary with scoped credentials.
-- `monitoring-cadvisor` should not share orchestration metadata or tracking
-  backend networks because it observes runtime internals.
-- `monitoring-mailhog` should remain dev-only and isolated from production-like
-  serving and tracking networks.
+- MinIO should stay inside the tracking backend boundary unless it becomes an
+  explicit artifact handoff boundary with scoped credentials.
+- MailHog should remain local-support-only.
 - `api-dev` should not share Airflow metadata, Redis, MLflow backend, or MinIO
   backend networks.
-- `airflow-worker` Docker socket access should not be combined with a broad
-  all-services integration network.
+- Docker socket access should not be introduced in the production-like runtime.
 
-## Target topology sketch
+## Topology sketch
 
 ```mermaid
 flowchart LR
     airflow[Airflow services] --> airflow_db[(airflow-postgres)]
     airflow --> airflow_redis[(airflow-redis)]
-    airflow --> runner[Worker or job runner]
+    airflow --> runner[Future job-runner-api]
     runner --> api[api-dev]
-    runner --> jobs[ML jobs]
+    runner --> jobs[Typed ML workers]
 
     jobs --> mlflow[mlflow-server]
     mlflow --> mlflow_db[(mlflow-postgres)]
     mlflow --> minio[(mlflow-minio)]
 
     jobs --> pushgateway[monitoring-pushgateway]
-    prometheus[monitoring-prometheus] --> api
-    prometheus --> pushgateway
-    prometheus --> cadvisor[monitoring-cadvisor]
+    pushgateway --> prometheus[monitoring-prometheus]
+    api --> prometheus
+    prometheus --> grafana[monitoring-grafana]
     prometheus --> alertmanager[monitoring-alertmanager]
-    grafana[monitoring-grafana] --> prometheus
     alertmanager --> mailhog[monitoring-mailhog]
-    airflow --> mailhog
 ```
 
-This sketch shows functional dependencies only. It is not an implementation
-diff for `docker/dev`.
+## Validation
 
-## Migration sequence
-
-1. Keep `docker/dev` unchanged and treat this document as the target contract.
-2. Create a separate `docker/prod` or `docker/local-prod` Compose entrypoint.
-3. Add the target network names without removing existing service definitions.
-4. Move Airflow metadata and broker services to `orchestration_net`.
-5. Create `pipeline_runtime_net` for Airflow worker or job runner, API refresh,
-   ML job containers, and Pushgateway writes.
-6. Move MLflow backend services to `tracking_backend_net`; attach ML jobs only
-   to `mlflow-server` through `tracking_client_net`.
-7. Replace the monitoring slice of `mlops_net` with `observability_net`.
-8. Move local SMTP capture to `dev_support_net` and keep it dev-only.
-9. Define the artifact handoff contract before removing broad `data`, `models`,
-   or `logs` bind mounts.
-10. Remove `mlops_net` from the target runtime only after all service-name
-    dependencies resolve through the new functional domains.
-11. Update architecture diagrams and operator documentation after validation.
-
-## Rollback criteria
-
-Rollback to the previous Compose topology or temporarily reattach the legacy
-integration network if any of these conditions occur:
-
-- `make compose-config` or `docker compose config` fails;
-- Prometheus cannot resolve or scrape expected targets;
-- Grafana cannot resolve or query Prometheus;
-- Alertmanager cannot receive alerts from Prometheus;
-- MailHog no longer receives local Airflow or Alertmanager email;
-- Airflow cannot reach PostgreSQL, Redis, the internal API server, or the API
-  refresh endpoint;
-- Airflow-created ML jobs cannot start or cannot join required networks;
-- ML jobs cannot log to MLflow or push metrics to Pushgateway;
-- `mlflow-server` cannot reach PostgreSQL or MinIO;
-- `api-dev` cannot read promoted prediction artifacts or expose `/metrics`.
-
-## Validation commands
-
-The documentation-only validation for this story remains:
+Network validation is expected through the runtime configuration and future smoke
+checks:
 
 ```bash
-make compose-config
+make prod-compose-config
+make prod-start
+make prod-ps
 ```
 
-Future implementation stories should also validate service-name resolution and
-runtime readiness with commands like:
-
-```bash
-docker compose config
-docker compose --profile ptf up -d
-docker compose ps
-docker compose exec monitoring-prometheus \
-    wget -qO- http://api-dev:10000/metrics
-docker compose exec monitoring-prometheus \
-    wget -qO- http://monitoring-alertmanager:9093/-/ready
-docker compose exec monitoring-grafana \
-    wget -qO- http://monitoring-prometheus:9090/-/ready
-docker compose exec airflow-worker getent hosts api-dev
-docker compose exec airflow-worker getent hosts monitoring-pushgateway
-docker compose exec mlflow-server getent hosts mlflow-postgres
-docker compose exec mlflow-server getent hosts mlflow-minio
-```
-
-## Out-of-scope items
-
-This design does not:
-
-- refactor the current `docker/dev` runtime;
-- implement `docker/prod`;
-- replace Airflow worker execution;
-- implement secrets or production ingress;
-- remove host bind mounts;
-- change monitoring, alerting, MLflow, MinIO, API, or Airflow service config.
+A dedicated production-like smoke target is tracked by Phase 8 and should verify
+runner reachability, API metrics scraping, artifact manifest availability, and the
+absence of Docker socket mounts in production-like Airflow services.

--- a/docs/local-prod-runtime.md
+++ b/docs/local-prod-runtime.md
@@ -1,13 +1,16 @@
 # Local Compose runtimes
 
-This document is the Phase 7 implementation note for issue #57. It introduces
-and explains the symmetric local Docker Compose runtime layout under
-`docker/dev` and `docker/prod`.
+This document describes the current local Docker Compose runtime model on
+`main` after Phases 6 and 7.
 
 The development runtime optimizes for debugging, host visibility, live-mounted
 runtime assets, and direct inspection of local service UIs. The production-like
 runtime optimizes for stricter local operation, reduced host exposure, functional
 networks, non-root custom application images, and explicit temporary exceptions.
+
+The Phase 7 implementation introduced the symmetric `docker/dev` and
+`docker/prod` layout. Phase 8 now focuses on replacing the remaining temporary
+exceptions with runner-based execution and manifest-based artifact handoff.
 
 ## When to use each runtime
 
@@ -22,9 +25,23 @@ logs, or model outputs. Use `docker/prod` when validating service boundaries,
 reduced host exposure, non-root application containers, isolated runtime
 workspaces, and the future runner migration path.
 
+## Related documentation
+
+Start from [`docs/README.md`](README.md) for the full documentation map.
+
+| Document | Role |
+| -------- | ---- |
+| [`repository-structure.md`](repository-structure.md) | Repository ownership, DVC boundaries, and runtime workspace ownership. |
+| [`ports-and-services.md`](ports-and-services.md) | Host exposure and internal-only services. |
+| [`runtime-communication-matrix.md`](runtime-communication-matrix.md) | Current service traffic and Phase 8 additions. |
+| [`runtime-security-boundaries.md`](runtime-security-boundaries.md) | Runtime identities, Docker socket risk, and security boundaries. |
+| [`local-prod-network-topology.md`](local-prod-network-topology.md) | Implemented production-like network topology. |
+| [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md) | Phase 8 hybrid manifest-first artifact handoff contract. |
+| [`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md) | Phase 8 runner-based Airflow execution target. |
+
 ## Operational commands
 
-The root Makefile now includes the dedicated runtime Makefiles:
+The root Makefile includes the dedicated runtime Makefiles:
 
 - `docker/dev/Makefile` for local development Compose operations;
 - `docker/prod/Makefile` for local production-like Compose operations.
@@ -43,9 +60,9 @@ make prod-ps
 
 ## Runtime workspace strategy
 
-The root `data`, `models`, and `logs` folders remain development, DVC, and
-host-local workspaces. They are still used by the development runtime and by
-local Python/DVC commands.
+The root `data`, `models`, and `logs` folders are development, DVC, and
+host-local workspaces. They are used by the development runtime and by local
+Python/DVC commands.
 
 The local production-like runtime writes to ignored runtime workspaces under
 `docker/prod/runtime`:
@@ -66,10 +83,14 @@ data/raw/comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv
 This keeps DVC ownership local to the root workspace while allowing `docker/prod`
 to run without writing into root `data`, `models`, or `logs`.
 
+Phase 8 adds a manifest-first handoff contract. The manifest becomes the
+promotion authority and may reference local runtime paths or optional MinIO object
+URIs. See [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md).
+
 ## Network topology
 
-The `docker/prod` Compose file follows the target functional network design from
-`docs/local-prod-network-topology.md`.
+The `docker/prod` Compose file implements the functional network design from
+[`local-prod-network-topology.md`](local-prod-network-topology.md).
 
 | Network | Main responsibility |
 | ------- | ------------------- |
@@ -84,29 +105,29 @@ The broad development `mlops_net` remains available in `docker/dev` because the
 current Airflow DockerOperator path depends on the development network model. It
 is not used by `docker/prod`.
 
-## Worker-pool status
+## Current worker-pool status
 
-The target worker-pool strategy from `docs/airflow-job-runner-strategy.md` is not
-fully implemented in this story. This runtime deliberately avoids pretending that
-the current DockerOperator path is production-like.
+`docker/prod` already removes the main production-like anti-pattern from Airflow:
+Airflow services do not mount `/var/run/docker.sock`.
 
-Current behavior in `docker/prod`:
+Current behavior:
 
-- Airflow services do not mount `/var/run/docker.sock`.
-- The Airflow worker does not run through the development root entrypoint.
+- Airflow services do not mount `/var/run/docker.sock` in `docker/prod`.
+- The Airflow worker does not run through the development Docker socket entrypoint.
 - Production-like Airflow config points to `pipeline_runtime_net`, not
   `mlops_net`.
-- Current DockerOperator-based ML DAG execution is a known temporary exception:
-  it remains available in `docker/dev`, not in `docker/prod`.
+- DockerOperator-based ML DAG execution remains available in `docker/dev` only.
 
-Expected follow-up:
+Remaining Phase 8 work:
 
 1. Add typed job submission schemas and a runner client under `src/`.
 2. Add an internal `job-runner-api` and typed ML worker services.
 3. Update the production-like DAG variant to submit runner jobs instead of
    creating containers.
-4. Validate init and daily DAGs through the runner before removing the temporary
-   exception from this document.
+4. Validate init and daily DAGs through the runner.
+
+The target design is documented in
+[`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md).
 
 ## Host exposure
 
@@ -135,11 +156,8 @@ and PostgreSQL services stay internal in `docker/prod`.
 | Airflow DAG/config files | Prod | Read-only | DAG and config placement is explicit for this runtime. |
 | Monitoring configs | Prod | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
 
-The artifact handoff strategy is documented in
-[`docs/artifact-handoff-strategy.md`](artifact-handoff-strategy.md). It keeps
-`docker/prod/runtime` as the first local backend while requiring API, Airflow,
-and runner consumers to use promoted manifests instead of implicit file
-conventions.
+Phase 8 hardens this model through explicit artifact manifests and promotion
+rules, not by making the root development workspace production-like.
 
 ## Runtime identities and exceptions
 
@@ -159,16 +177,16 @@ Documented exceptions:
 
 ## Secrets and placeholders
 
-`docker/dev` and `docker/prod` still read `.env` from the repository root. Do not
+`docker/dev` and `docker/prod` read `.env` from the repository root. Do not
 commit a populated `.env` file.
 
 The production-like Airflow config uses placeholder credentials where values are
-not safe to commit. Replace placeholders in a local branch or use a future secret
-injection mechanism before running authenticated flows.
+not safe to commit. Replace placeholders locally or use a future secret injection
+mechanism before running authenticated flows.
 
 ## Validation checklist
 
-Minimum validation for this story:
+Minimum validation:
 
 ```bash
 make dev-compose-config
@@ -181,18 +199,6 @@ Additional local smoke checks after startup:
 make dev-start
 make prod-start
 make prod-ps
-
-docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    -p trafic-cycliste-prod exec monitoring-prometheus \
-    wget -qO- http://api-dev:10000/metrics
-
-docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    -p trafic-cycliste-prod exec monitoring-grafana \
-    wget -qO- http://monitoring-prometheus:9090/-/ready
-
-docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    -p trafic-cycliste-prod exec mlflow-server getent hosts mlflow-postgres
-
-docker compose --env-file .env -f docker/prod/docker-compose.yaml \
-    -p trafic-cycliste-prod exec airflow-worker getent hosts api-dev
 ```
+
+A dedicated production-like smoke validation target is tracked by Phase 8.

--- a/docs/runtime-communication-matrix.md
+++ b/docs/runtime-communication-matrix.md
@@ -1,159 +1,120 @@
 # Runtime communication matrix
 
-This document describes the current local Docker Compose communication model for
-Phase 6. It is a review artifact for the local MLOps runtime, not a production
-security model.
+This document describes local Docker Compose communication after Phases 6 and 7.
+It is a runtime architecture reference, not a production security model.
 
-`docker-compose.yaml` is the source of truth for the runtime state. The diagrams
-in `references/Architecture_MLOps.drawio.png`,
-`references/Docker_Compose_Overview.drawio.png`, and
-`references/Docker_Compose_Monitoring.drawio.png` remain useful communication
-artifacts for the intended architecture and network responsibilities, but they
-may lag behind recent Compose changes.
+The current runtime has two Compose views:
+
+| Runtime | Compose file | Communication model |
+| ------- | ------------ | ------------------- |
+| Development | `docker/dev/docker-compose.yaml` | Broad local integration, DockerOperator execution, root `data/logs/models` mounts. |
+| Local production-like | `docker/prod/docker-compose.yaml` | Functional networks, reduced host exposure, no Docker socket in Airflow, isolated `docker/prod/runtime` workspaces. |
 
 Host port ranges and local URLs are documented in
-[`docs/ports-and-services.md`](ports-and-services.md). This document focuses on
-service-to-service communication, implicit coupling through shared mounts, and
-local-development boundaries that should be reviewed before a production-like
-split.
+[`ports-and-services.md`](ports-and-services.md). Runtime ownership and remaining
+exceptions are documented in [`local-prod-runtime.md`](local-prod-runtime.md).
 
-## Network responsibilities
+## Development communication model
 
-| Network | Responsibility | Production-like concern |
-| ------- | -------------- | ----------------------- |
-| `airflow_net` | Airflow control plane: API server, scheduler, DAG processor, triggerer, worker, Flower, Airflow PostgreSQL, Redis, and Airflow-managed tasks that need DAG-orchestration context. | Should stay limited to orchestration and Airflow dependencies. Business API access from this network should remain justified. |
-| `mlflow_net` | MLflow tracking and artifact plane: MLflow server, MLflow PostgreSQL, MinIO, MinIO initialization helper, and ML jobs that log runs or artifacts. | Should remain the default private boundary for tracking metadata and artifacts. |
-| `mlops_net` | Local platform integration plane: FastAPI, monitoring, Pushgateway, MailHog, cAdvisor, and services that need cross-stack integration. | Broad shared network. Useful locally, but a future production design should split monitoring, serving, and orchestration boundaries more strictly. |
+The development runtime keeps broad local visibility and current Airflow
+DockerOperator jobs.
 
-## Multiple-network attachments
+| Boundary | Main services | Purpose |
+| -------- | ------------- | ------- |
+| `airflow_net` | Airflow services, Airflow metadata DB, Redis, ML jobs | Airflow control plane and DockerOperator job context. |
+| `mlflow_net` | MLflow server, MLflow PostgreSQL, MinIO, model jobs | ML tracking and artifact logging. |
+| `mlops_net` | API, monitoring, Pushgateway, MailHog, cAdvisor, selected cross-stack services | Local integration and debugging. |
+| Root mounts | `data`, `models`, `logs` | Development, DVC, and host-visible artifacts. |
+| Docker socket | development `airflow-worker` only | Local DockerOperator execution. |
 
-| Service | Networks | Current justification | Cleanup candidate? |
-| ------- | -------- | --------------------- | ------------------ |
-| `ml-ingest-dev` | `airflow_net`, `mlops_net` | Can be triggered by Airflow and can push metrics to Pushgateway on `mlops_net`. | Keep for now while Airflow launches jobs through the local Docker socket and metrics target `monitoring-pushgateway`. |
-| `ml-features-dev` | `airflow_net`, `mlops_net` | Same batch orchestration and metrics-push pattern as ingestion. | Keep for now. |
-| `ml-models-dev` | `mlflow_net`, `airflow_net`, `mlops_net` | Needs MLflow/MinIO access, Airflow orchestration context, and Pushgateway metrics. | Keep for now; this is the clearest intentional cross-plane service. |
-| `api-dev` | `airflow_net`, `mlops_net` | Exposes FastAPI prediction and admin refresh endpoints; Airflow refresh currently targets the API after successful DAG runs. | Candidate for future cleanup if Airflow can reach the API through `mlops_net` only. Direct `airflow_net` access is not obviously required by the current Compose file. |
-| Airflow common services | `airflow_net`, `mlops_net` | Airflow services inherit `mlops_net` to reach platform services such as API, Pushgateway, MLflow, MinIO, or MailHog depending on runtime tasks. | Candidate for narrower per-service attachments later. Do not change blindly because DAG behavior depends on local DockerOperator and HTTP refresh flows. |
-| `airflow-worker` | `airflow_net`, `mlops_net` | Executes Celery tasks and runs local DockerOperator workloads through `/var/run/docker.sock`. | Keep for local development only; Docker socket access is privileged and not production-like. |
-| `airflow-flower` | `airflow_net` | Celery monitoring only; no cross-stack dependency documented. | No cleanup needed. |
-| `mlflow-minio` | `mlflow_net`, `mlops_net` | Private artifact store for MLflow, also host-exposed for local debugging and host-side clients. `mlops_net` attachment is not required for MLflow server access because both services share `mlflow_net`. | Candidate for future cleanup; prefer `mlflow_net` plus explicit host exposure unless a concrete `mlops_net` caller is retained. |
-| `mlflow-server` | `mlflow_net`, `mlops_net` | Tracks ML runs and exposes UI/API to host; `mlops_net` allows cross-stack calls from ML/API/monitoring services. | Candidate for future cleanup if all MLflow clients stay on `mlflow_net` or use host exposure deliberately. |
+The Docker socket path is a deliberate development exception. It must not be
+reintroduced in `docker/prod`.
 
-## Host-exposed versus internal-only services
+## Production-like communication model
 
-| Service | Internal port | Host port variable | Exposed to host? | Dev-only? | Reason |
-| ------- | ------------- | ------------------ | ---------------- | --------- | ------ |
-| `api-dev` | `10000` | `API_HOST_PORT` | Yes | No, local serving surface | FastAPI prediction API, OpenAPI docs, and admin refresh endpoint. |
-| `airflow-api-server` | `8080` | `AIRFLOW_HOST_PORT` | Yes | Local operations | Airflow UI and API for DAG validation and manual runs. |
-| `airflow-flower` | `5555` | `AIRFLOW_FLOWER_HOST_PORT` | Yes | Yes | Celery worker monitoring. |
-| `mlflow-minio` | `9000` | `MINIO_API_HOST_PORT` | Yes | Local artifact debugging | S3-compatible artifact endpoint for host-side clients. |
-| `mlflow-minio` | `9001` | `MINIO_CONSOLE_HOST_PORT` | Yes | Yes | MinIO browser console. |
-| `mlflow-server` | `5000` | `MLFLOW_HOST_PORT` | Yes | Local tracking UI/API | MLflow tracking, registry, and run inspection. |
-| `monitoring-prometheus` | `9090` | `PROMETHEUS_HOST_PORT` | Yes | Local observability | Prometheus UI and queries. |
-| `monitoring-pushgateway` | `9091` | `PUSHGATEWAY_HOST_PORT` | Yes | Local observability | Batch metrics debugging. |
-| `monitoring-alertmanager` | `9093` | `ALERTMANAGER_HOST_PORT` | Yes | Local observability | Alert routing and debug UI. |
-| `monitoring-cadvisor` | `8080` | `CADVISOR_HOST_PORT` | Yes | Local observability | Container metrics inspection. |
-| `monitoring-grafana` | `3000` | `GRAFANA_HOST_PORT` | Yes | Local observability | Dashboards. |
-| `monitoring-mailhog` | `1025` | `MAILHOG_SMTP_HOST_PORT` | Yes | Yes | Local SMTP capture endpoint. |
-| `monitoring-mailhog` | `8025` | `MAILHOG_UI_HOST_PORT` | Yes | Yes | MailHog web UI. |
-| `airflow-postgres` | `5432` | None | No | No | Airflow metadata database. |
-| `airflow-redis` | `6379` | None | No | No | Airflow Celery broker. |
-| `mlflow-postgres` | `5432` | None | No | No | MLflow metadata database. |
-| `mlflow-mc-init` | None | None | No | Yes | One-off MinIO bucket initialization helper. |
-| `airflow-init` | None | None | No | Yes | One-off Airflow initialization helper. |
-| `ml-ingest-dev` | None | None | No | Batch job | One-off or Airflow-triggered ingestion container. |
-| `ml-features-dev` | None | None | No | Batch job | One-off or Airflow-triggered feature container. |
-| `ml-models-dev` | None | None | No | Batch job | One-off or Airflow-triggered training and prediction container. |
+The production-like runtime uses functional networks implemented in
+[`local-prod-network-topology.md`](local-prod-network-topology.md).
 
-## Communication matrix
+| Boundary | Main services | Purpose |
+| -------- | ------------- | ------- |
+| `orchestration_net` | Airflow API, scheduler, DAG processor, triggerer, worker, Airflow PostgreSQL, Redis | Airflow control plane and metadata. |
+| `pipeline_runtime_net` | Airflow worker, API, ML jobs, Pushgateway, future runner API | Runtime handoff between orchestration, business jobs, refresh, and batch metrics. |
+| `tracking_client_net` | ML jobs, MLflow server | MLflow client calls. |
+| `tracking_backend_net` | MLflow server, MLflow PostgreSQL, MinIO, MC init | Private tracking metadata and artifact backend. |
+| `observability_net` | Prometheus, Grafana, Alertmanager, cAdvisor, Pushgateway, API metrics | Scrapes, dashboards, and local alerts. |
+| `dev_support_net` | MailHog, Alertmanager, Airflow email clients | Local support services. |
+| Runtime mounts | `docker/prod/runtime/data`, `docker/prod/runtime/models`, `docker/prod/runtime/logs` | Production-like generated data, models, and logs. |
 
-| Source service | Target service | Network | Internal port | Host-exposed port | Protocol | Authentication or credential boundary | Reason | Exposed to host? | Dev-only? | Production-like concern |
-| -------------- | -------------- | ------- | ------------- | ----------------- | -------- | ------------------------------------- | ------ | ---------------- | --------- | ----------------------- |
-| Host browser or API client | `api-dev` | Host port mapping | `10000` | `${API_HOST_PORT:-10000}` | HTTP | FastAPI application auth; local `.env` user defaults | Prediction API, OpenAPI docs, admin refresh validation | Yes | Local access path | Replace default credentials and define ingress/auth boundaries for production. |
-| Host browser or operator | `airflow-api-server` | Host port mapping | `8080` | `${AIRFLOW_HOST_PORT:-12080}` | HTTP | Airflow simple auth manager; local admin defaults | Airflow UI/API for DAG operations | Yes | Local operations | Simple auth is not a production-grade identity boundary. |
-| Host browser or operator | `airflow-flower` | Host port mapping | `5555` | `${AIRFLOW_FLOWER_HOST_PORT:-12555}` | HTTP | No explicit Compose auth boundary | Celery worker monitoring | Yes | Yes | Should not be exposed without auth in production-like runtime. |
-| Host browser or ML client | `mlflow-server` | Host port mapping | `5000` | `${MLFLOW_HOST_PORT:-13001}` | HTTP | MLflow allowed-hosts middleware; no Compose auth | MLflow tracking UI and host-side clients | Yes | Local tracking | Add identity and network restrictions before production exposure. |
-| Host S3 client or browser | `mlflow-minio` | Host port mapping | `9000` / `9001` | `${MINIO_API_HOST_PORT:-13000}` / `${MINIO_CONSOLE_HOST_PORT:-13002}` | HTTP/S3 | MinIO root credentials from `.env` | Artifact store API and console debugging | Yes | Local artifact debugging | Root credentials and console exposure must be hardened or removed. |
-| Host browser or operator | `monitoring-prometheus` | Host port mapping | `9090` | `${PROMETHEUS_HOST_PORT:-14090}` | HTTP | No explicit Compose auth boundary | Prometheus UI and query debugging | Yes | Local observability | Restrict UI and admin APIs in production-like runtime. |
-| Host browser or operator | `monitoring-grafana` | Host port mapping | `3000` | `${GRAFANA_HOST_PORT:-14300}` | HTTP | Grafana admin credentials from `.env` | Dashboards | Yes | Local observability | Rotate credentials and define SSO/role model later. |
-| Host browser or operator | `monitoring-cadvisor` | Host port mapping | `8080` | `${CADVISOR_HOST_PORT:-14200}` | HTTP | No explicit Compose auth boundary | Container metrics debugging | Yes | Local observability | Exposes runtime metadata; should not be public. |
-| Host browser or operator | `monitoring-pushgateway` | Host port mapping | `9091` | `${PUSHGATEWAY_HOST_PORT:-14091}` | HTTP | No explicit Compose auth boundary | Inspect pushed batch metrics | Yes | Local observability | Restrict writes and lifecycle management in production-like runtime. |
-| Host browser or operator | `monitoring-alertmanager` | Host port mapping | `9093` | `${ALERTMANAGER_HOST_PORT:-14093}` | HTTP | No explicit Compose auth boundary | Alert routing inspection | Yes | Local observability | Restrict UI and API access. |
-| Host SMTP client or browser | `monitoring-mailhog` | Host port mapping | `1025` / `8025` | `${MAILHOG_SMTP_HOST_PORT:-15025}` / `${MAILHOG_UI_HOST_PORT:-15080}` | SMTP/HTTP | No real mail delivery; local capture only | Validate email routing locally | Yes | Yes | Replace with real SMTP provider and secrets in production. |
-| `airflow-api-server`, `airflow-scheduler`, `airflow-dag-processor`, `airflow-triggerer`, `airflow-worker` | `airflow-postgres` | `airflow_net` | `5432` | None | PostgreSQL | `AIRFLOW_POSTGRES_*` credentials | Airflow metadata database and Celery result backend | No | No | Keep private; rotate credentials and use managed DB later if needed. |
-| `airflow-scheduler`, `airflow-worker`, `airflow-flower` | `airflow-redis` | `airflow_net` | `6379` | None | Redis | No Redis password in current broker URL | Celery broker | No | No | Add broker auth or managed broker for production-like runtime. |
-| `airflow-api-server`, `airflow-scheduler`, `airflow-dag-processor`, `airflow-triggerer`, `airflow-worker` | `airflow-api-server` | `airflow_net` | `8080` | `${AIRFLOW_HOST_PORT:-12080}` | HTTP | `AIRFLOW_API_AUTH_JWT_SECRET` for Airflow execution API | Internal Airflow execution API and UI/API service | Partly | No | Keep internal execution API off public networks. |
-| `airflow-worker` | Docker daemon on host | Bind mount, not Docker network | `/var/run/docker.sock` | None | Unix socket / Docker API | Host Docker group/root-equivalent boundary | Local DockerOperator workload creation for ML jobs | No | Yes | Privileged local-development boundary; not a production orchestration model. |
-| Airflow DAG tasks | `ml-ingest-dev` container | Docker daemon then `mlops_net` / `airflow_net` | N/A | None | Docker API | Docker socket and container env variables | Trigger ingestion as part of init/daily DAGs | No | Local orchestration | Prefer worker queue, KubernetesPodOperator, or managed job runtime later. |
-| Airflow DAG tasks | `ml-features-dev` container | Docker daemon then `mlops_net` / `airflow_net` | N/A | None | Docker API | Docker socket and container env variables | Trigger feature engineering after ingestion | No | Local orchestration | Same privileged Docker socket concern. |
-| Airflow DAG tasks | `ml-models-dev` container | Docker daemon then `mlflow_net` / `mlops_net` / `airflow_net` | N/A | None | Docker API | Docker socket, MLflow/MinIO credentials, env variables | Trigger training and prediction after features | No | Local orchestration | Same privileged Docker socket concern. |
-| Airflow DAG tasks | `api-dev` | `mlops_net` or `airflow_net` | `10000` | `${API_HOST_PORT:-10000}` | HTTP | API Basic Auth / admin role | `POST /admin/refresh` after successful init or daily run | Yes | No | `api-dev` probably does not need `airflow_net`; validate before cleanup. |
-| `api-dev` | Shared `./data` mount | Volume bind mount | N/A | N/A | Filesystem | Host filesystem permissions | Read final prediction data from `DATA_FINAL_ROOT` | No | Local runtime | Replace shared mutable filesystem with artifact contract or object storage. |
-| `ml-ingest-dev` | Shared `./data`, `./logs` mounts | Volume bind mount | N/A | N/A | Filesystem | Host filesystem permissions | Read raw data, write interim data and logs | No | Batch job | Shared ownership can hide data contracts and race conditions. |
-| `ml-features-dev` | Shared `./data`, `./logs` mounts | Volume bind mount | N/A | N/A | Filesystem | Host filesystem permissions | Read interim data, write processed features and logs | No | Batch job | Same shared mutable filesystem concern. |
-| `ml-models-dev` | Shared `./data`, `./models`, `./logs` mounts | Volume bind mount | N/A | N/A | Filesystem | Host filesystem permissions | Read processed data, write predictions, model artifacts, and logs | No | Batch job | Promote explicit artifact storage and ownership boundaries later. |
-| `ml-models-dev` | `mlflow-server` | `mlflow_net` | `5000` | `${MLFLOW_HOST_PORT:-13001}` | HTTP | `MLFLOW_TRACKING_URI`; no explicit MLflow auth in Compose mode | Log runs, params, metrics, models, and artifacts | Partly | No | Add MLflow auth/registry governance for production-like runtime. |
-| `ml-models-dev` | `mlflow-minio` | `mlflow_net` | `9000` | `${MINIO_API_HOST_PORT:-13000}` | HTTP/S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `MLFLOW_S3_ENDPOINT_URL` | Store MLflow artifacts | Partly | No | Avoid root credentials and restrict bucket policies. |
-| `mlflow-server` | `mlflow-postgres` | `mlflow_net` | `5432` | None | PostgreSQL | `MLFLOW_POSTGRES_*` credentials | MLflow backend store | No | No | Keep private; use managed DB or least-privilege credentials later. |
-| `mlflow-server` | `mlflow-minio` | `mlflow_net` | `9000` | `${MINIO_API_HOST_PORT:-13000}` | HTTP/S3 | MinIO credentials from `.env` | MLflow artifact storage backend | Partly | No | Keep artifact store private except deliberate local host exposure. |
-| `mlflow-mc-init` | `mlflow-minio` | `mlflow_net` | `9000` | `${MINIO_API_HOST_PORT:-13000}` | HTTP/S3 | MinIO root credentials | Create and configure the `mlflow` bucket | Partly | Yes | One-off init with elevated credentials should not be long-lived. |
-| `ml-ingest-dev`, `ml-features-dev`, `ml-models-dev` | `monitoring-pushgateway` | `mlops_net` | `9091` | `${PUSHGATEWAY_HOST_PORT:-14091}` | HTTP | Controlled by `DISABLE_METRICS_PUSH`; no auth | Push batch metrics when enabled | Yes | Local metrics path | Add write controls and job lifecycle cleanup later. |
-| `api-dev` | `monitoring-prometheus` scrape target | `mlops_net` | `10000` | `${API_HOST_PORT:-10000}` | HTTP `/metrics` | No scrape auth | API technical and business metrics | Yes | No | Decide whether metrics stay on serving network or separate monitoring network. |
-| `monitoring-prometheus` | `api-dev` | `mlops_net` | `10000` | `${API_HOST_PORT:-10000}` | HTTP `/metrics` | No scrape auth | Scrape API metrics | Yes | No | Same monitoring-network separation concern. |
-| `monitoring-prometheus` | `monitoring-cadvisor` | `mlops_net` | `8080` | `${CADVISOR_HOST_PORT:-14200}` | HTTP | No scrape auth | Scrape host/container metrics | Yes | Local observability | cAdvisor is privileged and mounts host runtime paths. |
-| `monitoring-prometheus` | `monitoring-pushgateway` | `mlops_net` | `9091` | `${PUSHGATEWAY_HOST_PORT:-14091}` | HTTP | No scrape auth | Scrape pushed batch metrics | Yes | Local observability | Review metric retention and stale series cleanup later. |
-| `monitoring-prometheus` | `monitoring-alertmanager` | `mlops_net` | `9093` | `${ALERTMANAGER_HOST_PORT:-14093}` | HTTP | No explicit Compose auth | Send firing alerts to Alertmanager | Yes | Local observability | Restrict alert APIs and notification routes. |
-| `monitoring-grafana` | `monitoring-prometheus` | `mlops_net` | `9090` | `${PROMETHEUS_HOST_PORT:-14090}` | HTTP | Grafana datasource config; no Prometheus auth | Query metrics for dashboards | Yes | Local observability | Add datasource secrets and network isolation later. |
-| `monitoring-alertmanager` | `monitoring-mailhog` | `mlops_net` | `1025` | `${MAILHOG_SMTP_HOST_PORT:-15025}` | SMTP | MailHog capture only; TLS disabled | Validate alert emails locally | Yes | Yes | Replace with authenticated SMTP and TLS in production. |
-| Airflow services | `monitoring-mailhog` | `mlops_net` | `1025` | `${MAILHOG_SMTP_HOST_PORT:-15025}` | SMTP | MailHog capture only; TLS disabled | Capture Airflow emails locally | Yes | Yes | Replace with authenticated SMTP and TLS in production. |
-| `monitoring-cadvisor` | Host Docker/runtime paths | Bind mounts | N/A | N/A | Filesystem / Docker socket | Privileged container and host mounts | Collect container and host metrics | Yes | Local observability | Privileged host access must be redesigned for production. |
+## Current service-to-service paths
 
-## Shared mounts and implicit ownership coupling
+| Source | Target | Runtime | Mechanism | Reason |
+| ------ | ------ | ------- | --------- | ------ |
+| Airflow services | Airflow PostgreSQL | Dev and prod-like | Compose DNS, PostgreSQL | Metadata database and result backend. |
+| Airflow services | Airflow Redis | Dev and prod-like | Compose DNS, Redis | Celery broker. |
+| Airflow DAG tasks | ML job containers | Dev only | Docker socket / DockerOperator | Current local development ML execution. |
+| Airflow DAG tasks | `api-dev` | Dev and prod-like | HTTP on internal network | Refresh API after successful DAG runs. |
+| ML jobs | Pushgateway | Dev and prod-like | HTTP | Batch metric push when enabled. |
+| ML model jobs | MLflow server | Dev and prod-like | HTTP | Run, parameter, metric, model, and artifact logging. |
+| MLflow server | MLflow PostgreSQL | Dev and prod-like | PostgreSQL | MLflow backend store. |
+| MLflow server | MinIO | Dev and prod-like | S3/HTTP | MLflow artifact store. |
+| Prometheus | API, Pushgateway, cAdvisor | Dev and prod-like | HTTP scrape | Metrics collection. |
+| Grafana | Prometheus | Dev and prod-like | HTTP | Provisioned datasource. |
+| Alertmanager | MailHog | Dev and prod-like | SMTP | Local alert capture. |
+| API | Prediction artifacts | Dev and prod-like | Filesystem | Current prediction serving input. Phase 8 moves this to manifest-aware serving. |
 
-| Mount | Used by | Coupling created | Production-like concern |
-| ----- | ------- | ---------------- | ----------------------- |
-| `./data:/app/data` | ML jobs, `api-dev` | ML jobs write datasets and predictions that the API reads directly. | Define a versioned data/artifact contract before separating runtime roles. |
-| `./data:/opt/airflow/data` | Airflow services | DAGs and Airflow tasks can inspect or coordinate data files. | Avoid implicit orchestration decisions based on mutable shared files where possible. |
-| `./logs:/app/logs` | ML jobs, `api-dev` | Runtime logs are shared with the host and possibly other containers. | Centralize logs through logging infrastructure later. |
-| `./logs:/opt/airflow/logs` | Airflow services | Airflow logs are host-visible and shared by Airflow components. | Expected locally; production should use remote log storage. |
-| `./models:/app/models` | `ml-models-dev` | Model files are written to a host-mounted directory. | Prefer MLflow registry/artifact storage as the primary model handoff. |
-| `./docker/dev/airflow/dags:/opt/airflow/dags` | Airflow services | DAG code is live-mounted from the repository. | Good for local development; production should deploy immutable DAG artifacts. |
-| `./docker/dev/airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro` | Airflow services | Business DAG configuration is read directly from the repository. | Keep configuration versioned, but separate environment-specific values later. |
-| `./docker/dev/airflow/config/:/opt/airflow/config/` | `airflow-init` | Airflow variables and connections are imported from repository files. | Do not keep real secrets in repository-managed config files. |
-| `/var/run/docker.sock:/var/run/docker.sock` | `airflow-worker`, `monitoring-cadvisor` | Gives privileged access to host Docker runtime. | Local-development boundary only; not production-like. |
-| `./docker/dev/prometheus:/etc/prometheus:ro` | `monitoring-prometheus` | Prometheus scrape and alert rules are repository-mounted. | Expected locally; production should deploy validated config artifacts. |
-| `./docker/dev/grafana/provisioning:/etc/grafana/provisioning:ro` | `monitoring-grafana` | Grafana datasources and dashboards are repository-provisioned. | Expected locally; secure datasource secrets later. |
-| `./docker/dev/grafana/dashboards:/var/lib/grafana/dashboards` | `monitoring-grafana` | Dashboard JSON files are live-mounted. | Useful locally; package dashboards as immutable artifacts later. |
-| `./docker/dev/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro` | `monitoring-alertmanager` | Alert routing is repository-mounted. | Replace MailHog test routes and secure notification secrets later. |
-| `mlflow-postgres-db` | `mlflow-postgres` | Persistent MLflow metadata. | Private service volume; backup and migration strategy required later. |
-| `mlflow-minio-data` | `mlflow-minio` | Persistent MLflow artifacts. | Private artifact store; backup, lifecycle, and credential rotation needed later. |
-| `airflow-postgres-db` | `airflow-postgres` | Persistent Airflow metadata. | Private service volume; backup and migration strategy required later. |
-| `airflow-redis-data` | `airflow-redis` | Persistent Redis broker data. | Review persistence needs and broker durability later. |
-| `monitoring-prometheus-data` | `monitoring-prometheus` | Persistent metrics time-series data. | Retention and storage planning required for production-like monitoring. |
-| `monitoring-grafana-data` | `monitoring-grafana` | Persistent Grafana state. | Backup and provisioning strategy required later. |
-| `monitoring-alertmanager-data` | `monitoring-alertmanager` | Persistent alertmanager state. | Review silences and notification state management. |
+## Host exposure summary
 
-## Explicit cleanup candidates for later stories
+Development intentionally exposes more local UIs. The production-like runtime
+publishes only operator-facing services by default.
 
-- Validate whether `api-dev` needs `airflow_net`. Current evidence suggests Airflow
-  only needs HTTP access to the API for `/admin/refresh`, which can likely stay on
-  `mlops_net`.
-- Validate whether `mlflow-server` and `mlflow-minio` need `mlops_net`. Their core
-  communication is already covered by `mlflow_net`; host exposure covers local UI
-  and host-side clients.
-- Split Airflow services more narrowly if DAG behavior allows it. The inherited
-  `x-airflow-common` network list is convenient locally but broad.
-- Replace Airflow worker Docker socket usage with a production-like job runtime
-  such as a controlled worker image, a remote Docker boundary, or Kubernetes
-  orchestration.
-- Move secrets out of default local files and into a dedicated secret-management
-  boundary as part of the runtime identity and permissions story.
+| Service family | Development exposure | Production-like exposure |
+| -------------- | -------------------- | ------------------------ |
+| FastAPI | Host exposed | Host exposed |
+| Airflow API/UI | Host exposed | Host exposed |
+| MLflow UI/API | Host exposed | Host exposed |
+| Grafana | Host exposed | Host exposed |
+| MinIO API/console | Host exposed | Internal-only |
+| Prometheus | Host exposed | Internal-only |
+| Pushgateway | Host exposed | Internal-only |
+| Alertmanager | Host exposed | Internal-only |
+| cAdvisor | Host exposed | Internal-only |
+| MailHog | Host exposed | Internal-only |
+| PostgreSQL and Redis | Internal-only | Internal-only |
 
-## Validation
+See [`ports-and-services.md`](ports-and-services.md) for exact ports and URLs.
 
-No functional runtime change is introduced by this document. The expected Compose
-validation command remains:
+## Shared mount coupling
 
-```bash
-make compose-config
-```
+| Mount | Runtime | Current role | Phase 8 direction |
+| ----- | ------- | ------------ | ----------------- |
+| Root `data` | Dev | Raw, interim, processed, final data for DVC/local workflows. | Remains dev/DVC-owned. |
+| Root `models` | Dev | Development model artifacts. | Remains dev/DVC-owned. |
+| Root `logs` | Dev | Development logs. | Remains dev-owned. |
+| `docker/prod/runtime/data` | Prod-like | Generated production-like data. | Referenced by artifact manifests. |
+| `docker/prod/runtime/models` | Prod-like | Generated production-like model artifacts. | Referenced by artifact manifests. |
+| `docker/prod/runtime/logs` | Prod-like | Production-like service and job logs. | Correlate with runner `job_id` and `run_id`. |
+| Root raw CSV | Prod-like | Read-only business source input. | Remains the only required root/DVC input. |
+
+## Phase 8 expected additions
+
+Phase 8 introduces explicit contracts instead of adding broad communication paths.
+
+| Addition | Expected communication | Reference |
+| -------- | ---------------------- | --------- |
+| Artifact manifests | ML jobs write manifests; API and runner read promoted manifests. | [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md) |
+| Job contracts | Airflow and runner exchange typed job payloads. | [`airflow-job-runner-strategy.md`](airflow-job-runner-strategy.md) |
+| `job-runner-api` | Airflow submits jobs through `pipeline_runtime_net`; service is internal-only. | #68 |
+| Runner execution | Runner executes typed jobs and returns manifest references. | #69 |
+| Prod Airflow DAG | Airflow observes runner job states instead of creating containers. | #70 |
+| Artifact-aware API | API serves the promoted artifact described by `current.json`. | #71 |
+| Smoke validation | Automated checks verify runner, Airflow, artifact, API, and monitoring connectivity. | #72 |
+
+## Rules for future changes
+
+- Do not add Docker socket mounts to production-like Airflow services.
+- Do not copy the broad `mlops_net` development model into `docker/prod`.
+- Prefer explicit functional networks over pairwise networks unless sensitive
+  state or privileged control surfaces require isolation.
+- Keep host exposure in `ports-and-services.md` synchronized with Compose.
+- Keep artifact handoff changes aligned with
+  [`artifact-handoff-strategy.md`](artifact-handoff-strategy.md).


### PR DESCRIPTION
## Summary

Consolidates the post-Phase 7 documentation hierarchy now that Phases 6 and 7 are implemented and Phase 8 has started.

## Changes

- Add `docs/README.md` as the documentation entrypoint.
- Reframe `docs/local-prod-runtime.md` as the current dev/prod runtime guide instead of a Phase 7 implementation note.
- Reframe `docs/local-prod-network-topology.md` as the implemented `docker/prod` network reference, with explicit Phase 8 additions.
- Reframe `docs/airflow-job-runner-strategy.md` as a Phase 8 target design, now aware of the current Phase 7 state and the merged artifact handoff strategy.
- Rework `docs/runtime-communication-matrix.md` to separate current dev/prod communication from Phase 8 expected additions.
- Update Phase 8 issues #64 to #73 so their references point to the consolidated documentation map and the relevant runtime/architecture docs.

## Notes

The root `README.md` should eventually point primarily to `docs/README.md` instead of listing multiple detailed runtime docs inline. I attempted a full replacement, but the GitHub tool rejected the write because of existing content in the complete file. I kept this PR focused on `/docs/` and issue bodies to avoid an unsafe broad rewrite.

## Validation

Documentation-only change. I reviewed the affected documents for consistency with:

- current `docker/dev` / `docker/prod` split;
- merged artifact handoff design from #63 / PR #74;
- Phase 8 story references and dependencies.

No runtime validation required.