### PR TITLE
feat: implement artifact manifest models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Project-specific agent rules
+
+## Project context
+
+- Treat this repository as a Python/MLOps platform for Paris bike traffic
+  prediction.
+- Keep a Machine Learning Engineer / MLOps perspective: reproducibility,
+  artifact traceability, orchestration, monitoring, API serving, and runtime
+  boundaries matter.
+- Work from `main` and create one branch per issue, story, or bugfix.
+- Open PRs against `main`; never merge without human review.
+
+## Code rules
+
+- Use English for code, variables, functions, classes, logs, comments,
+  docstrings, tests, and API payloads.
+- Keep Python code compatible with Python 3.12, PEP8, Ruff, and the current
+  `pyproject.toml`.
+- Prefer small, cohesive commits grouped by logical intent, not one commit per
+  file.
+- Put reusable Python logic in `src/`; put tests under `tests/`.
+- Keep framework-neutral contracts independent from FastAPI, Airflow, Docker,
+  or CLI internals unless the story explicitly targets integration code.
+
+## Tests and validation
+
+- Follow the existing class-based pytest style when adding unit tests.
+- Add or update tests for every functional contract change.
+- Prefer targeted validation first, then broader checks when relevant:
+  `make lint`, `make tests`, `make checks`.
+- Mention commands actually run in the PR body. Do not claim unrun validation.
+
+## Documentation
+
+- Keep the root `README.md` concise and project-oriented.
+- Put runtime commands and workspace ownership in
+  `docs/current-runtime-and-operations/`.
+- Put cross-runtime architecture rules in `docs/architecture-references/`.
+- Put Phase 8 target designs and implementation notes in
+  `docs/next-phase-design/`.
+- When a design becomes implemented, update wording from future-state to
+  current-state and leave remaining gaps explicit.
+
+## Runtime and artifacts
+
+- Preserve the dev/prod split: root `data/`, `models/`, and `logs/` are
+  development/DVC workspaces; `docker/prod/runtime/` is local production-like
+  runtime space.
+- Prefer explicit artifact manifests over implicit filesystem discovery.
+- Do not add secrets, local `.env` values, generated artifacts, or runtime
+  payloads to Git.
+- Do not widen Docker mounts, exposed ports, or network access without a story
+  explaining the runtime impact.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Use these documents when implementing Phase 8 stories.
 | Document | Purpose |
 | -------- | ------- |
 | [`next-phase-design/artifact-handoff-strategy.md`](next-phase-design/artifact-handoff-strategy.md) | Hybrid manifest-first artifact promotion contract using local runtime paths and optional MinIO object URIs. |
+| [`next-phase-design/artifact-manifest-models.md`](next-phase-design/artifact-manifest-models.md) | Implemented Pydantic artifact manifest models, validation rules, and test coverage for issue #64. |
 | [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md) | Target runner-based Airflow execution model that replaces DockerOperator in `docker/prod`. |
 
 ## Reading order
@@ -52,9 +53,10 @@ For runtime work, read:
 For Phase 8 implementation, read:
 
 1. [`next-phase-design/artifact-handoff-strategy.md`](next-phase-design/artifact-handoff-strategy.md)
-2. [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md)
-3. [`architecture-references/local-prod-network-topology.md`](architecture-references/local-prod-network-topology.md)
-4. The issue body for the current Phase 8 story.
+2. [`next-phase-design/artifact-manifest-models.md`](next-phase-design/artifact-manifest-models.md)
+3. [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md)
+4. [`architecture-references/local-prod-network-topology.md`](architecture-references/local-prod-network-topology.md)
+5. The issue body for the current Phase 8 story.
 
 ## Documentation rules
 

--- a/docs/next-phase-design/artifact-manifest-models.md
+++ b/docs/next-phase-design/artifact-manifest-models.md
@@ -1,0 +1,83 @@
+# Artifact manifest models
+
+This document records the implementation outcome for Phase 8 issue #64. The
+hybrid artifact handoff design remains documented in
+[`artifact-handoff-strategy.md`](artifact-handoff-strategy.md).
+
+## Implemented package
+
+The reusable Python contract lives under:
+
+```text
+src/artifacts/
+├── __init__.py
+├── exceptions.py
+└── schemas.py
+```
+
+The package is intentionally independent from Airflow and FastAPI internals so
+ML jobs, the future runner, Airflow integration code, and API serving code can
+share the same validated manifest contract.
+
+## Models and enums
+
+`src/artifacts/schemas.py` exposes:
+
+- `ArtifactManifest`;
+- `ArtifactProducer`;
+- `ArtifactSource`;
+- `ArtifactStorage`;
+- `ArtifactType`;
+- `ArtifactStatus`;
+- `StorageBackend`;
+- `validate_artifact_manifest`.
+
+The initial schema version is `1.0`. The implementation uses Pydantic field
+descriptions and docstrings so the contract remains readable for developers and
+can be reused by generated documentation later.
+
+## Validation rules
+
+The manifest model validates:
+
+- required fields: schema version, artifact type, status, run id, counter id,
+  creation timestamp, producer, source, and storage;
+- local-only manifests with repository-relative `local_path` values;
+- hybrid manifests with local paths plus optional `s3://` object URIs;
+- storage backend values through constrained enums;
+- URI-like local paths, absolute paths, and parent traversal;
+- SHA-256 checksums when present;
+- timezone-aware `created_at` timestamps;
+- undeclared fields through strict Pydantic configuration.
+
+The first runtime implementation still uses `primary_backend="local"`.
+`object_uri` remains optional and only records the S3-compatible reference when
+the artifact is also available through MinIO or another object store.
+
+## Test coverage
+
+Unit tests live in:
+
+```text
+tests/artifacts/test_artifact_manifest_schemas.py
+```
+
+They cover the acceptance cases from issue #64:
+
+- valid local manifest;
+- valid hybrid manifest;
+- missing required field;
+- invalid backend;
+- invalid URI cases.
+
+## Remaining Phase 8 work
+
+This story only implements the manifest contract. The following topics remain
+for later Phase 8 stories:
+
+- writing manifests to disk;
+- checksum verification against real payloads;
+- promotion helpers and `current.json` replacement;
+- ML job emission of manifests;
+- API serving from promoted manifests;
+- MinIO upload/download helpers.

--- a/src/artifacts/__init__.py
+++ b/src/artifacts/__init__.py
@@ -1,0 +1,26 @@
+"""Artifact contract models shared across MLOps components."""
+
+from artifacts.exceptions import ArtifactManifestError, ArtifactManifestValidationError
+from artifacts.schemas import (
+    ArtifactManifest,
+    ArtifactProducer,
+    ArtifactSource,
+    ArtifactStatus,
+    ArtifactStorage,
+    ArtifactType,
+    StorageBackend,
+    validate_artifact_manifest,
+)
+
+__all__ = [
+    "ArtifactManifest",
+    "ArtifactManifestError",
+    "ArtifactManifestValidationError",
+    "ArtifactProducer",
+    "ArtifactSource",
+    "ArtifactStatus",
+    "ArtifactStorage",
+    "ArtifactType",
+    "StorageBackend",
+    "validate_artifact_manifest",
+]

--- a/src/artifacts/exceptions.py
+++ b/src/artifacts/exceptions.py
@@ -1,0 +1,11 @@
+"""Custom exceptions for artifact manifest handling."""
+
+from __future__ import annotations
+
+
+class ArtifactManifestError(ValueError):
+    """Base exception raised by artifact manifest helpers."""
+
+
+class ArtifactManifestValidationError(ArtifactManifestError):
+    """Raised when a raw artifact manifest payload fails validation."""

--- a/src/artifacts/schemas.py
+++ b/src/artifacts/schemas.py
@@ -1,0 +1,261 @@
+"""Pydantic schemas for artifact handoff manifests.
+
+The manifest is the shared contract between ML jobs, Airflow, future runners,
+and the prediction API. It stays independent from runtime framework internals.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from enum import StrEnum
+from pathlib import PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from artifacts.exceptions import ArtifactManifestValidationError
+
+SCHEMA_VERSION = "1.0"
+_SHA256_PATTERN = re.compile(r"^[a-fA-F0-9]{64}$")
+
+
+class ArtifactType(StrEnum):
+    """Supported artifact categories exchanged through manifests."""
+
+    PREDICTIONS = "predictions"
+    MODEL = "model"
+    DATASET = "dataset"
+    METRICS = "metrics"
+
+
+class ArtifactStatus(StrEnum):
+    """Lifecycle states documented in the artifact handoff strategy."""
+
+    PRODUCED = "produced"
+    VALIDATED = "validated"
+    PROMOTED = "promoted"
+    SERVED = "served"
+    ARCHIVED = "archived"
+
+
+class StorageBackend(StrEnum):
+    """Artifact storage backends supported by the manifest contract."""
+
+    LOCAL = "local"
+    OBJECT_STORAGE = "object_storage"
+
+
+class StrictArtifactModel(BaseModel):
+    """Base model forbidding undeclared manifest fields."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        validate_assignment=True,
+    )
+
+
+class ArtifactProducer(StrictArtifactModel):
+    """Component that produced the artifact payload and metadata."""
+
+    service: str = Field(
+        min_length=1,
+        description="Service or job name that produced the artifact.",
+    )
+    image: str | None = Field(
+        default=None,
+        description="Container image reference used by the producer.",
+    )
+    version: str | None = Field(
+        default=None,
+        description="Optional producer code or package version.",
+    )
+
+
+class ArtifactSource(StrictArtifactModel):
+    """Input lineage used to produce the artifact."""
+
+    raw_file_name: str | None = Field(
+        default=None,
+        description="Raw input file name or external source label.",
+    )
+    dataset_version: str | None = Field(
+        default=None,
+        description="DVC revision, snapshot label, or runtime input version.",
+    )
+    model_version: str | None = Field(
+        default=None,
+        description="MLflow run, registry version, or local release label.",
+    )
+
+    @model_validator(mode="after")
+    def validate_lineage_metadata(self) -> "ArtifactSource":
+        """Require at least one lineage reference in the source block."""
+
+        values = (self.raw_file_name, self.dataset_version, self.model_version)
+        if not any(values):
+            raise ValueError("source must include at least one lineage reference")
+
+        return self
+
+
+class ArtifactStorage(StrictArtifactModel):
+    """Storage references for local-only and hybrid artifact handoff."""
+
+    primary_backend: StorageBackend = Field(
+        description="Primary backend used by consumers for this artifact.",
+    )
+    local_path: str | None = Field(
+        default=None,
+        description="Repository-relative path to the local artifact payload.",
+    )
+    object_uri: str | None = Field(
+        default=None,
+        description="Optional S3-compatible object URI for hybrid handoff.",
+    )
+    checksum_sha256: str | None = Field(
+        default=None,
+        description="SHA-256 checksum of the canonical artifact payload.",
+    )
+
+    @field_validator("local_path")
+    @classmethod
+    def validate_local_path(cls, value: str | None) -> str | None:
+        """Reject empty, absolute, parent-traversal, and URI-like paths."""
+
+        if value is None:
+            return None
+        if not value:
+            raise ValueError("local_path must not be empty")
+
+        parsed = urlparse(value)
+        if parsed.scheme:
+            raise ValueError("local_path must be a repository-relative path")
+
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("local_path must stay inside the repository")
+
+        return value
+
+    @field_validator("object_uri")
+    @classmethod
+    def validate_object_uri(cls, value: str | None) -> str | None:
+        """Require S3-compatible object URIs without embedded credentials."""
+
+        if value is None:
+            return None
+        if not value:
+            raise ValueError("object_uri must not be empty")
+
+        parsed = urlparse(value)
+        if parsed.scheme != "s3":
+            raise ValueError("object_uri must use the s3:// scheme")
+        if not parsed.netloc or parsed.netloc.strip() != parsed.netloc:
+            raise ValueError("object_uri must include a valid bucket name")
+        if not parsed.path or parsed.path == "/":
+            raise ValueError("object_uri must include an object key")
+        if "@" in parsed.netloc:
+            raise ValueError("object_uri must not embed credentials")
+
+        return value
+
+    @field_validator("checksum_sha256")
+    @classmethod
+    def validate_checksum_sha256(cls, value: str | None) -> str | None:
+        """Require checksums to use the standard 64-character hex format."""
+
+        if value is None:
+            return None
+
+        if not _SHA256_PATTERN.fullmatch(value):
+            raise ValueError("checksum_sha256 must be a 64-character hex digest")
+
+        return value.lower()
+
+    @model_validator(mode="after")
+    def validate_backend_references(self) -> "ArtifactStorage":
+        """Ensure every backend has the references it needs."""
+
+        if self.primary_backend == StorageBackend.LOCAL and self.local_path is None:
+            raise ValueError("local_path is required for local storage")
+
+        if (
+            self.primary_backend == StorageBackend.OBJECT_STORAGE
+            and self.object_uri is None
+        ):
+            raise ValueError("object_uri is required for object storage")
+
+        if self.local_path is None and self.object_uri is None:
+            raise ValueError("storage must include local_path or object_uri")
+
+        return self
+
+
+class ArtifactManifest(StrictArtifactModel):
+    """Validated manifest describing one generated artifact."""
+
+    schema_version: str = Field(
+        description="Manifest schema version. The initial contract uses 1.0.",
+    )
+    artifact_type: ArtifactType = Field(
+        description="Type of artifact referenced by the manifest.",
+    )
+    status: ArtifactStatus = Field(
+        description="Lifecycle status of the referenced artifact.",
+    )
+    run_id: str = Field(
+        min_length=1,
+        description="Unique run identifier for the artifact production attempt.",
+    )
+    counter_id: str = Field(
+        min_length=1,
+        description="Project counter identifier associated with the artifact.",
+    )
+    created_at: datetime = Field(
+        description="UTC timestamp for manifest creation.",
+    )
+    producer: ArtifactProducer = Field(
+        description="Producer metadata and execution identity.",
+    )
+    source: ArtifactSource = Field(
+        description="Input data and model lineage metadata.",
+    )
+    storage: ArtifactStorage = Field(
+        description="Local and optional object-storage artifact references.",
+    )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: str) -> str:
+        """Keep the implementation pinned to the documented schema version."""
+
+        if value != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+
+        return value
+
+    @field_validator("created_at")
+    @classmethod
+    def validate_created_at(cls, value: datetime) -> datetime:
+        """Require timezone-aware creation timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+
+        return value
+
+
+def validate_artifact_manifest(payload: Mapping[str, Any]) -> ArtifactManifest:
+    """Validate a raw payload and return an artifact manifest instance.
+
+    Raises:
+        ArtifactManifestValidationError: if Pydantic rejects the payload.
+    """
+
+    try:
+        return ArtifactManifest.model_validate(payload)
+    except ValueError as error:
+        raise ArtifactManifestValidationError(str(error)) from error

--- a/src/artifacts/schemas.py
+++ b/src/artifacts/schemas.py
@@ -7,10 +7,11 @@ and the prediction API. It stays independent from runtime framework internals.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
 from pathlib import PurePosixPath
-from typing import Any, Mapping
+from typing import Any
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -91,7 +92,7 @@ class ArtifactSource(StrictArtifactModel):
     )
 
     @model_validator(mode="after")
-    def validate_lineage_metadata(self) -> "ArtifactSource":
+    def validate_lineage_metadata(self) -> ArtifactSource:
         """Require at least one lineage reference in the source block."""
 
         values = (self.raw_file_name, self.dataset_version, self.model_version)
@@ -176,7 +177,7 @@ class ArtifactStorage(StrictArtifactModel):
         return value.lower()
 
     @model_validator(mode="after")
-    def validate_backend_references(self) -> "ArtifactStorage":
+    def validate_backend_references(self) -> ArtifactStorage:
         """Ensure every backend has the references it needs."""
 
         if self.primary_backend == StorageBackend.LOCAL and self.local_path is None:

--- a/tests/artifacts/test_artifact_manifest_schemas.py
+++ b/tests/artifacts/test_artifact_manifest_schemas.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from artifacts.schemas import ArtifactManifest, StorageBackend
 
-
 VALID_CHECKSUM = "a" * 64
 
 

--- a/tests/artifacts/test_artifact_manifest_schemas.py
+++ b/tests/artifacts/test_artifact_manifest_schemas.py
@@ -1,0 +1,111 @@
+"""Unit tests for artifact manifest schemas."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from artifacts.schemas import ArtifactManifest, StorageBackend
+
+
+VALID_CHECKSUM = "a" * 64
+
+
+class TestArtifactManifest:
+    """Unit tests for ArtifactManifest."""
+
+    @pytest.fixture
+    def valid_local_manifest(self) -> dict:
+        return {
+            "schema_version": "1.0",
+            "artifact_type": "predictions",
+            "status": "promoted",
+            "run_id": "2026-06-06T140000Z-sebastopol-ns",
+            "counter_id": "Sebastopol_N-S_airflow",
+            "created_at": "2026-06-06T14:00:00Z",
+            "producer": {
+                "service": "ml-models-prod",
+                "image": "ml-models:prod",
+            },
+            "source": {
+                "raw_file_name": "bike-counts.csv",
+                "dataset_version": "local-dev-dvc",
+                "model_version": "mlflow-run-20260606",
+            },
+            "storage": {
+                "primary_backend": "local",
+                "local_path": (
+                    "docker/prod/runtime/artifacts/data/final/"
+                    "Sebastopol_N-S_airflow/"
+                    "2026-06-06T140000Z-sebastopol-ns/predictions.parquet"
+                ),
+                "checksum_sha256": VALID_CHECKSUM,
+            },
+        }
+
+    def test_valid_local_manifest(self, valid_local_manifest):
+        manifest = ArtifactManifest.model_validate(valid_local_manifest)
+
+        assert manifest.storage.primary_backend == StorageBackend.LOCAL
+        assert manifest.storage.local_path.endswith("predictions.parquet")
+        assert manifest.storage.object_uri is None
+
+    def test_valid_hybrid_manifest(self, valid_local_manifest):
+        payload = deepcopy(valid_local_manifest)
+        payload["storage"]["object_uri"] = (
+            "s3://mlflow/artifacts/predictions/"
+            "Sebastopol_N-S_airflow/"
+            "2026-06-06T140000Z-sebastopol-ns/predictions.parquet"
+        )
+
+        manifest = ArtifactManifest.model_validate(payload)
+
+        assert manifest.storage.primary_backend == StorageBackend.LOCAL
+        assert manifest.storage.object_uri.startswith("s3://mlflow/")
+
+    def test_missing_required_field_raises_validation_error(
+        self,
+        valid_local_manifest,
+    ):
+        payload = deepcopy(valid_local_manifest)
+        payload.pop("run_id")
+
+        with pytest.raises(ValidationError, match="run_id"):
+            ArtifactManifest.model_validate(payload)
+
+    def test_invalid_backend_raises_validation_error(self, valid_local_manifest):
+        payload = deepcopy(valid_local_manifest)
+        payload["storage"]["primary_backend"] = "filesystem"
+
+        with pytest.raises(ValidationError, match="primary_backend"):
+            ArtifactManifest.model_validate(payload)
+
+    @pytest.mark.parametrize(
+        ("field_name", "invalid_value", "message"),
+        [
+            (
+                "local_path",
+                "https://example.com/artifacts/predictions.parquet",
+                "repository-relative",
+            ),
+            (
+                "object_uri",
+                "https://minio/artifacts/predictions.parquet",
+                "s3://",
+            ),
+        ],
+    )
+    def test_invalid_uri_cases_raise_validation_error(
+        self,
+        valid_local_manifest,
+        field_name,
+        invalid_value,
+        message,
+    ):
+        payload = deepcopy(valid_local_manifest)
+        payload["storage"][field_name] = invalid_value
+
+        with pytest.raises(ValidationError, match=message):
+            ArtifactManifest.model_validate(payload)


### PR DESCRIPTION
## Summary

Implements Phase 8 issue #64 with a reusable artifact manifest contract package.

- Add `src/artifacts/` with Pydantic manifest schemas, enums, and custom validation exception.
- Validate local-only and hybrid local/S3 artifact storage references.
- Cover required fields, invalid backend, missing field, and invalid URI cases with unit tests.
- Add documentation for the implemented manifest models and link it from `docs/README.md`.

## Validation

- `PYTHONPATH=src pytest -q tests/artifacts/test_artifact_manifest_schemas.py`
- Result: `6 passed`

## Notes for review

- The models stay independent from Airflow and FastAPI internals as requested.
- Manifest writing, promotion, MinIO helpers, and API serving changes remain out of scope for follow-up Phase 8 stories.

Refs #64