### PR TITLE
docs: clarify Phase 8 current vs next documentation boundary

### DIFF
--- a/docs/architecture-references/runtime-communication-matrix.md
+++ b/docs/architecture-references/runtime-communication-matrix.md
@@ -1,8 +1,11 @@
 # Runtime communication matrix
 
-This document describes local Docker Compose communication after Phases 6 and 7,
-with Phase 8 artifact and job contracts now partially implemented. It is a
-runtime architecture reference, not a production security model.
+This document describes the implemented local Docker Compose communication model.
+It is a current-state runtime architecture reference, not a Phase 8 backlog or a
+production security model.
+
+Planned runtime changes, remaining Phase 8 work, and validation debt are tracked
+under [`../next-phase-design/`](../next-phase-design/).
 
 The current runtime has two Compose views:
 
@@ -13,8 +16,22 @@ The current runtime has two Compose views:
 
 Host port ranges and local URLs are documented in
 [`../current-runtime-and-operations/ports-and-services.md`](../current-runtime-and-operations/ports-and-services.md).
-Runtime ownership and remaining exceptions are documented in
+Runtime ownership and current exceptions are documented in
 [`../current-runtime-and-operations/local-prod-runtime.md`](../current-runtime-and-operations/local-prod-runtime.md).
+
+## Documentation boundary
+
+Use this document for implemented runtime communication only:
+
+- current services;
+- current networks;
+- current mounts;
+- current host exposure;
+- current service-to-service paths.
+
+Use [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md)
+and [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md)
+for target architecture, remaining Phase 8 work, and known validation debt.
 
 ## Development communication model
 
@@ -40,7 +57,7 @@ The production-like runtime uses functional networks implemented in
 | Boundary | Main services | Purpose |
 | -------- | ------------- | ------- |
 | `orchestration_net` | Airflow API, scheduler, DAG processor, triggerer, worker, Airflow PostgreSQL, Redis | Airflow control plane and metadata. |
-| `pipeline_runtime_net` | Airflow worker, API, ML jobs, Pushgateway, future runner API | Runtime handoff between orchestration, business jobs, refresh, and batch metrics. |
+| `pipeline_runtime_net` | Airflow worker, API, ML jobs, Pushgateway | Runtime handoff between orchestration, business jobs, refresh, and batch metrics. |
 | `tracking_client_net` | ML jobs, MLflow server | MLflow client calls. |
 | `tracking_backend_net` | MLflow server, MLflow PostgreSQL, MinIO, MC init | Private tracking metadata and artifact backend. |
 | `observability_net` | Prometheus, Grafana, Alertmanager, cAdvisor, Pushgateway, API metrics | Scrapes, dashboards, and local alerts. |
@@ -62,7 +79,7 @@ The production-like runtime uses functional networks implemented in
 | Prometheus | API, Pushgateway, cAdvisor | Dev and prod-like | HTTP scrape | Metrics collection. |
 | Grafana | Prometheus | Dev and prod-like | HTTP | Provisioned datasource. |
 | Alertmanager | MailHog | Dev and prod-like | SMTP | Local alert capture. |
-| API | Prediction artifacts | Dev and prod-like | Filesystem | Current prediction serving input. Phase 8 moves this to manifest-aware serving. |
+| API | Prediction artifacts | Dev and prod-like | Filesystem | Current prediction serving input. |
 
 ## Host exposure summary
 
@@ -86,57 +103,32 @@ publishes only operator-facing services by default.
 See [`../current-runtime-and-operations/ports-and-services.md`](../current-runtime-and-operations/ports-and-services.md)
 for exact ports and URLs.
 
-## Shared mount coupling
+## Shared mount ownership
 
-| Mount | Runtime | Current role | Phase 8 direction |
-| ----- | ------- | ------------ | ----------------- |
-| Root `data` | Dev | Raw, interim, processed, final data for DVC/local workflows. | Remains dev/DVC-owned. |
-| Root `models` | Dev | Development model artifacts. | Remains dev/DVC-owned. |
-| Root `logs` | Dev | Development logs. | Remains dev-owned. |
-| `docker/prod/runtime/data` | Prod-like | Generated production-like data. | Referenced by artifact manifests. |
-| `docker/prod/runtime/models` | Prod-like | Generated production-like model artifacts. | Referenced by artifact manifests. |
-| `docker/prod/runtime/logs` | Prod-like | Production-like service and job logs. | Correlate with runner `job_id` and `run_id`. |
-| `docker/prod/runtime/artifacts` | Prod-like | Manifest-first handoff root. | Owns promoted `current.json` and run-scoped manifests. |
-| Root raw CSV | Prod-like | Read-only business source input. | Remains the only required root/DVC input. |
+| Mount | Runtime | Current role |
+| ----- | ------- | ------------ |
+| Root `data` | Dev | Raw, interim, processed, final data for DVC/local workflows. |
+| Root `models` | Dev | Development model artifacts. |
+| Root `logs` | Dev | Development logs. |
+| `docker/prod/runtime/data` | Prod-like | Generated production-like data. |
+| `docker/prod/runtime/models` | Prod-like | Generated production-like model artifacts. |
+| `docker/prod/runtime/logs` | Prod-like | Production-like service and job logs. |
+| `docker/prod/runtime/artifacts` | Prod-like | Manifest-first handoff root with run-scoped manifests and promoted `current.json` files. |
+| Root raw CSV | Prod-like | Read-only business source input. |
 
-## Phase 8 coverage and status
+## Current Phase 8 state in this architecture
 
-Phase 8 introduces explicit contracts instead of adding broad communication paths.
-The remaining plan is tracked centrally in
-[`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md).
+The implemented runtime already includes the artifact workspace, ML manifest
+emission wiring, and typed contract packages needed by the future runner path.
+It does not currently include a `job-runner-api` service, runner execution path,
+production-like Airflow DAG that calls the runner, or API serving from promoted
+manifests.
 
-| Addition | Status | Expected communication | Reference |
-| -------- | ------ | ---------------------- | --------- |
-| Artifact manifest schemas | Implemented | Shared Python contract used by ML, runner, and API integrations. | [`../next-phase-design/artifact-manifest-models.md`](../next-phase-design/artifact-manifest-models.md) |
-| Artifact manifest store | Implemented | Local helpers write run manifests and replace `current.json`. | [`../next-phase-design/artifact-manifest-store.md`](../next-phase-design/artifact-manifest-store.md) |
-| ML manifest emission | Implemented for local manifests | Ingest, features, and model jobs can emit promoted local manifests under `docker/prod/runtime/artifacts`. | #66 |
-| Job contracts | Implemented | Airflow, runner, and typed workers exchange Pydantic job payloads and statuses. | [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md) |
-| `job-runner-api` | Remaining | Airflow submits jobs through `pipeline_runtime_net`; service is internal-only. | #68 |
-| Runner execution | Remaining | Runner executes typed jobs and returns manifest references. | #69 |
-| Prod Airflow DAG | Remaining | Airflow observes runner job states instead of creating containers. | #70 |
-| Artifact-aware API | Remaining | API serves the promoted artifact described by `current.json`. | #71 |
-| Smoke validation | Remaining | Automated checks verify runner, Airflow, artifact, API, and monitoring connectivity. | #72 |
+Those target changes are tracked under
+[`../next-phase-design/`](../next-phase-design/), not in this current-state
+matrix.
 
-The current implementation therefore covers the artifact and contract foundation,
-but not yet the end-to-end production-like execution path. `docker/prod` is
-safer because Airflow has no Docker socket mount, but the replacement runner path
-still has to be implemented before it is fully executable through Airflow.
-
-## Known Phase 8 validation debt
-
-Phase 8 still needs a dedicated validation story for realistic, production-like
-coverage. The minimum debt to track is:
-
-- broader unit coverage for manifest errors, runner states, API artifact loading,
-  and configuration failures;
-- integration fixtures derived from the real raw-data schema instead of only
-  synthetic minimal examples;
-- at least one smoke-sized dataset that exercises ingest, features, model,
-  manifest promotion, API load, and monitoring checks;
-- explicit documentation of which fixture size is safe for CI and which one is
-  intended for local production-like validation.
-
-## Rules for future changes
+## Operational guardrails
 
 - Do not add Docker socket mounts to production-like Airflow services.
 - Do not copy the broad `mlops_net` development model into `docker/prod`.
@@ -144,5 +136,3 @@ coverage. The minimum debt to track is:
   state or privileged control surfaces require isolation.
 - Keep host exposure in `../current-runtime-and-operations/ports-and-services.md`
   synchronized with Compose.
-- Keep artifact handoff changes aligned with
-  [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md).

--- a/docs/architecture-references/runtime-communication-matrix.md
+++ b/docs/architecture-references/runtime-communication-matrix.md
@@ -1,8 +1,8 @@
 # Runtime communication matrix
 
 This document describes local Docker Compose communication after Phases 6 and 7,
-with Phase 8 artifact contracts now partially implemented. It is a runtime
-architecture reference, not a production security model.
+with Phase 8 artifact and job contracts now partially implemented. It is a
+runtime architecture reference, not a production security model.
 
 The current runtime has two Compose views:
 
@@ -99,7 +99,7 @@ for exact ports and URLs.
 | `docker/prod/runtime/artifacts` | Prod-like | Manifest-first handoff root. | Owns promoted `current.json` and run-scoped manifests. |
 | Root raw CSV | Prod-like | Read-only business source input. | Remains the only required root/DVC input. |
 
-## Phase 8 additions and status
+## Phase 8 coverage and status
 
 Phase 8 introduces explicit contracts instead of adding broad communication paths.
 The remaining plan is tracked centrally in
@@ -107,15 +107,34 @@ The remaining plan is tracked centrally in
 
 | Addition | Status | Expected communication | Reference |
 | -------- | ------ | ---------------------- | --------- |
-| Artifact manifest schemas | Implemented | Shared Python contract used by later ML, runner, and API integrations. | [`../next-phase-design/artifact-manifest-models.md`](../next-phase-design/artifact-manifest-models.md) |
-| Artifact manifest store | Implemented | Local helpers write run manifests and replace `current.json`; runtime services do not call them yet. | [`../next-phase-design/artifact-manifest-store.md`](../next-phase-design/artifact-manifest-store.md) |
-| ML manifest emission | Remaining | ML model jobs emit validated prediction manifests. | #66 |
-| Job contracts | Remaining | Airflow and runner exchange typed job payloads. | [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md) |
+| Artifact manifest schemas | Implemented | Shared Python contract used by ML, runner, and API integrations. | [`../next-phase-design/artifact-manifest-models.md`](../next-phase-design/artifact-manifest-models.md) |
+| Artifact manifest store | Implemented | Local helpers write run manifests and replace `current.json`. | [`../next-phase-design/artifact-manifest-store.md`](../next-phase-design/artifact-manifest-store.md) |
+| ML manifest emission | Implemented for local manifests | Ingest, features, and model jobs can emit promoted local manifests under `docker/prod/runtime/artifacts`. | #66 |
+| Job contracts | Implemented | Airflow, runner, and typed workers exchange Pydantic job payloads and statuses. | [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md) |
 | `job-runner-api` | Remaining | Airflow submits jobs through `pipeline_runtime_net`; service is internal-only. | #68 |
 | Runner execution | Remaining | Runner executes typed jobs and returns manifest references. | #69 |
 | Prod Airflow DAG | Remaining | Airflow observes runner job states instead of creating containers. | #70 |
 | Artifact-aware API | Remaining | API serves the promoted artifact described by `current.json`. | #71 |
 | Smoke validation | Remaining | Automated checks verify runner, Airflow, artifact, API, and monitoring connectivity. | #72 |
+
+The current implementation therefore covers the artifact and contract foundation,
+but not yet the end-to-end production-like execution path. `docker/prod` is
+safer because Airflow has no Docker socket mount, but the replacement runner path
+still has to be implemented before it is fully executable through Airflow.
+
+## Known Phase 8 validation debt
+
+Phase 8 still needs a dedicated validation story for realistic, production-like
+coverage. The minimum debt to track is:
+
+- broader unit coverage for manifest errors, runner states, API artifact loading,
+  and configuration failures;
+- integration fixtures derived from the real raw-data schema instead of only
+  synthetic minimal examples;
+- at least one smoke-sized dataset that exercises ingest, features, model,
+  manifest promotion, API load, and monitoring checks;
+- explicit documentation of which fixture size is safe for CI and which one is
+  intended for local production-like validation.
 
 ## Rules for future changes
 

--- a/docs/current-runtime-and-operations/local-prod-runtime.md
+++ b/docs/current-runtime-and-operations/local-prod-runtime.md
@@ -1,7 +1,7 @@
 # Local Compose runtimes
 
 This document describes the current local Docker Compose runtime model on `main`
-after Phases 6 and 7, with the Phase 8 artifact contract now partially
+after Phases 6 and 7, with the Phase 8 artifact and job contracts now partially
 implemented in reusable Python helpers.
 
 The development runtime optimizes for debugging, host visibility, live-mounted
@@ -18,7 +18,7 @@ exceptions with runner-based execution and manifest-based artifact handoff.
 | Runtime | Entry point | Primary use |
 | ------- | ----------- | ----------- |
 | Development | `docker/dev/docker-compose.yaml` | Debugging, local demos, broad host visibility, DockerOperator-based Airflow ML jobs. |
-| Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, monitoring smoke tests, and Phase 8 runner integration (#67-#70). |
+| Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, monitoring smoke tests, and Phase 8 runner integration (#68-#72). |
 
 Use `docker/dev` when iterating on DAGs, ML CLI containers, root-level DVC data,
 logs, or model outputs.
@@ -38,7 +38,7 @@ Start from [`../README.md`](../README.md) for the full documentation map.
 | -------- | ---- |
 | [`repository-structure.md`](repository-structure.md) | Repository ownership, DVC boundaries, and runtime workspace ownership. |
 | [`ports-and-services.md`](ports-and-services.md) | Host exposure and internal-only services. |
-| [`../architecture-references/runtime-communication-matrix.md`](../architecture-references/runtime-communication-matrix.md) | Current service traffic and Phase 8 additions. |
+| [`../architecture-references/runtime-communication-matrix.md`](../architecture-references/runtime-communication-matrix.md) | Current service traffic, Phase 8 coverage, and remaining validation debt. |
 | [`../architecture-references/runtime-security-boundaries.md`](../architecture-references/runtime-security-boundaries.md) | Runtime identities, Docker socket risk, and security boundaries. |
 | [`../architecture-references/local-prod-network-topology.md`](../architecture-references/local-prod-network-topology.md) | Implemented production-like network topology. |
 | [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md) | Phase 8 hybrid manifest-first artifact handoff contract and remaining plan. |
@@ -97,9 +97,11 @@ data/raw/comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv
 This keeps DVC ownership local to the root workspace while allowing `docker/prod`
 to run without writing into root `data`, `models`, or `logs`.
 
-Phase 8 now provides reusable manifest models and store helpers. Runtime services
-still need later stories to emit, promote, and consume those manifests.
-The remaining artifact plan is tracked in
+Phase 8 now provides reusable manifest models, store helpers, ML manifest
+emission wrappers, and typed job contracts. Runtime services still need later
+stories to execute jobs through the runner, make Airflow call the runner, and
+make the API serve from promoted manifests. The remaining artifact plan is
+tracked in
 [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md).
 
 ## Network topology
@@ -110,7 +112,7 @@ The `docker/prod` Compose file implements the functional network design from
 | Network | Main responsibility |
 | ------- | ------------------- |
 | `orchestration_net` | Airflow control plane, metadata DB, broker, and internal execution API. |
-| `pipeline_runtime_net` | API refresh, batch job handoff, and Pushgateway writes. |
+| `pipeline_runtime_net` | API refresh, batch job handoff, future runner API, and Pushgateway writes. |
 | `tracking_client_net` | MLflow client calls from model workloads. |
 | `tracking_backend_net` | MLflow PostgreSQL and MinIO backend isolation. |
 | `observability_net` | Prometheus scrapes, Grafana datasource access, and alert routing. |
@@ -131,6 +133,13 @@ Current behavior:
 - The Airflow worker does not run through the development Docker socket entrypoint.
 - Production-like Airflow config points to `pipeline_runtime_net`, not `mlops_net`.
 - DockerOperator-based ML DAG execution remains available in `docker/dev` only.
+- ML services can emit local promoted manifests when `ARTIFACT_MANIFEST_ROOT` is
+  configured.
+- Typed job contracts exist for the runner path, but the runner API and worker
+  execution are not implemented yet.
+
+This means `docker/prod` is safer than the development runtime, but it is not yet
+fully executable through Airflow without the remaining runner stories.
 
 Remaining runner work is tracked in
 [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md).
@@ -159,6 +168,7 @@ and PostgreSQL services stay internal in `docker/prod`.
 | `docker/prod/runtime/data` | Prod | Writable | Temporary production-like data workspace. |
 | `docker/prod/runtime/models` | Prod | Writable | Temporary production-like model workspace. |
 | `docker/prod/runtime/logs` | Prod | Writable | Temporary production-like log workspace. |
+| `docker/prod/runtime/artifacts` | Prod | Writable by ML jobs today; future API mount should be read-only | Manifest-first handoff root. |
 | Airflow DAG/config files | Prod | Read-only | DAG and config placement is explicit for this runtime. |
 | Monitoring configs | Prod | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
 
@@ -190,6 +200,10 @@ The production-like Airflow config uses placeholder credentials where values are
 not safe to commit. Replace placeholders locally or use a future secret injection
 mechanism before running authenticated flows.
 
+Phase 8 hardening should reject placeholder values where they are unsafe for
+runtime behavior, while keeping documented local demo placeholders acceptable
+where they are explicitly non-sensitive.
+
 ## Validation checklist
 
 Minimum validation:
@@ -207,4 +221,8 @@ make prod-start
 make prod-ps
 ```
 
-A dedicated production-like smoke validation target is tracked by Phase 8.
+A dedicated production-like smoke validation target is tracked by Phase 8. It
+should eventually prove runner health, Airflow-to-runner communication, promoted
+manifest availability, API artifact metadata, API prediction serving from the
+promoted artifact, monitoring scrape availability, and the absence of Docker
+socket mounts in production-like Airflow.

--- a/docs/current-runtime-and-operations/local-prod-runtime.md
+++ b/docs/current-runtime-and-operations/local-prod-runtime.md
@@ -1,8 +1,10 @@
 # Local Compose runtimes
 
-This document describes the current local Docker Compose runtime model on `main`
-after Phases 6 and 7, with the Phase 8 artifact and job contracts now partially
-implemented in reusable Python helpers.
+This document describes the implemented local Docker Compose runtime model on
+`main`. It is a current-state operational guide, not a Phase 8 backlog.
+
+Planned runtime changes, remaining Phase 8 work, and validation debt are tracked
+under [`../next-phase-design/`](../next-phase-design/).
 
 The development runtime optimizes for debugging, host visibility, live-mounted
 runtime assets, and direct inspection of local service UIs. The production-like
@@ -10,25 +12,40 @@ runtime optimizes for stricter local operation, reduced host exposure, functiona
 networks, non-root custom application images, and explicit temporary exceptions.
 
 The Phase 7 implementation introduced the symmetric `docker/dev` and
-`docker/prod` layout. Phase 8 focuses on replacing the remaining temporary
-exceptions with runner-based execution and manifest-based artifact handoff.
+`docker/prod` layout. The current Phase 8 implementation adds manifest and job
+contract foundations, while the runner execution path remains planned work.
 
 ## When to use each runtime
 
 | Runtime | Entry point | Primary use |
 | ------- | ----------- | ----------- |
 | Development | `docker/dev/docker-compose.yaml` | Debugging, local demos, broad host visibility, DockerOperator-based Airflow ML jobs. |
-| Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, monitoring smoke tests, and Phase 8 runner integration (#68-#72). |
+| Local production-like | `docker/prod/docker-compose.yaml` | Network and exposure validation, least-privilege rehearsal, isolated runtime workspaces, and monitoring smoke checks. |
 
 Use `docker/dev` when iterating on DAGs, ML CLI containers, root-level DVC data,
 logs, or model outputs.
 
-Use `docker/prod` when validating service boundaries, reduced host exposure,
-non-root application containers, isolated runtime workspaces, and the Phase 8
-runner migration path.
+Use `docker/prod` when validating implemented service boundaries, reduced host
+exposure, non-root application containers, and isolated runtime workspaces.
 
 Do not use a root-level Compose file. Runtime commands must go through the
 runtime-specific Make targets or an explicit `docker compose -f` command.
+
+## Documentation boundary
+
+Use this document for current runtime operation:
+
+- current commands;
+- current workspaces;
+- current networks;
+- current mounts;
+- current service exposure;
+- current security exceptions.
+
+Use [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md)
+and [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md)
+for target runner behavior, artifact-aware API serving, future smoke validation,
+configuration hardening, and remaining Phase 8 tracking.
 
 ## Related documentation
 
@@ -37,13 +54,12 @@ Start from [`../README.md`](../README.md) for the full documentation map.
 | Document | Role |
 | -------- | ---- |
 | [`repository-structure.md`](repository-structure.md) | Repository ownership, DVC boundaries, and runtime workspace ownership. |
-| [`ports-and-services.md`](ports-and-services.md) | Host exposure and internal-only services. |
-| [`../architecture-references/runtime-communication-matrix.md`](../architecture-references/runtime-communication-matrix.md) | Current service traffic, Phase 8 coverage, and remaining validation debt. |
+| [`ports-and-services.md`](ports-and-services.md) | Implemented host exposure and internal-only services. |
+| [`../architecture-references/runtime-communication-matrix.md`](../architecture-references/runtime-communication-matrix.md) | Implemented service traffic, networks, and mounts. |
 | [`../architecture-references/runtime-security-boundaries.md`](../architecture-references/runtime-security-boundaries.md) | Runtime identities, Docker socket risk, and security boundaries. |
 | [`../architecture-references/local-prod-network-topology.md`](../architecture-references/local-prod-network-topology.md) | Implemented production-like network topology. |
-| [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md) | Phase 8 hybrid manifest-first artifact handoff contract and remaining plan. |
-| [`../next-phase-design/artifact-manifest-store.md`](../next-phase-design/artifact-manifest-store.md) | Implemented manifest store helpers available to future runtime consumers. |
-| [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md) | Phase 8 runner-based Airflow execution target. |
+| [`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md) | Phase 8 target artifact handoff and remaining plan. |
+| [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md) | Phase 8 target runner-based Airflow execution. |
 
 ## Operational commands
 
@@ -85,7 +101,7 @@ The local production-like runtime writes to ignored runtime workspaces under
 | `docker/prod/runtime/data` | Production-like generated data workspace. |
 | `docker/prod/runtime/models` | Production-like generated model workspace. |
 | `docker/prod/runtime/logs` | Production-like service and batch logs. |
-| `docker/prod/runtime/artifacts` | Phase 8 manifest-first artifact handoff root. |
+| `docker/prod/runtime/artifacts` | Manifest-first artifact handoff root. |
 
 Only the required business source CSV is mounted from the root development/DVC
 workspace into the production-like ingestion service as read-only input:
@@ -97,12 +113,11 @@ data/raw/comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv
 This keeps DVC ownership local to the root workspace while allowing `docker/prod`
 to run without writing into root `data`, `models`, or `logs`.
 
-Phase 8 now provides reusable manifest models, store helpers, ML manifest
-emission wrappers, and typed job contracts. Runtime services still need later
-stories to execute jobs through the runner, make Airflow call the runner, and
-make the API serve from promoted manifests. The remaining artifact plan is
-tracked in
-[`../next-phase-design/artifact-handoff-strategy.md`](../next-phase-design/artifact-handoff-strategy.md).
+Current Phase 8 foundations available to runtime services:
+
+- reusable artifact manifest models and store helpers;
+- ML manifest emission wrappers;
+- typed job request and status contracts.
 
 ## Network topology
 
@@ -111,8 +126,8 @@ The `docker/prod` Compose file implements the functional network design from
 
 | Network | Main responsibility |
 | ------- | ------------------- |
-| `orchestration_net` | Airflow control plane, metadata DB, broker, and internal execution API. |
-| `pipeline_runtime_net` | API refresh, batch job handoff, future runner API, and Pushgateway writes. |
+| `orchestration_net` | Airflow control plane, metadata DB, and broker. |
+| `pipeline_runtime_net` | API refresh, batch job handoff, and Pushgateway writes. |
 | `tracking_client_net` | MLflow client calls from model workloads. |
 | `tracking_backend_net` | MLflow PostgreSQL and MinIO backend isolation. |
 | `observability_net` | Prometheus scrapes, Grafana datasource access, and alert routing. |
@@ -135,14 +150,11 @@ Current behavior:
 - DockerOperator-based ML DAG execution remains available in `docker/dev` only.
 - ML services can emit local promoted manifests when `ARTIFACT_MANIFEST_ROOT` is
   configured.
-- Typed job contracts exist for the runner path, but the runner API and worker
-  execution are not implemented yet.
+- Typed job contracts exist for the planned runner path.
 
-This means `docker/prod` is safer than the development runtime, but it is not yet
-fully executable through Airflow without the remaining runner stories.
-
-Remaining runner work is tracked in
-[`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md).
+A `job-runner-api` service, runner execution path, and production-like Airflow
+DAG that calls the runner are not part of the current runtime yet. They are
+tracked in [`../next-phase-design/airflow-job-runner-strategy.md`](../next-phase-design/airflow-job-runner-strategy.md).
 
 ## Host exposure
 
@@ -165,10 +177,10 @@ and PostgreSQL services stay internal in `docker/prod`.
 | ----- | ------- | ------ | ------ |
 | Root `data`, `models`, `logs` | Dev | Writable | Debug visibility, local DVC, and current DockerOperator jobs. |
 | Root source CSV | Prod | Read-only | Required business input for ingestion. |
-| `docker/prod/runtime/data` | Prod | Writable | Temporary production-like data workspace. |
-| `docker/prod/runtime/models` | Prod | Writable | Temporary production-like model workspace. |
-| `docker/prod/runtime/logs` | Prod | Writable | Temporary production-like log workspace. |
-| `docker/prod/runtime/artifacts` | Prod | Writable by ML jobs today; future API mount should be read-only | Manifest-first handoff root. |
+| `docker/prod/runtime/data` | Prod | Writable | Production-like generated data workspace. |
+| `docker/prod/runtime/models` | Prod | Writable | Production-like model workspace. |
+| `docker/prod/runtime/logs` | Prod | Writable | Production-like service and batch log workspace. |
+| `docker/prod/runtime/artifacts` | Prod | Writable by ML jobs | Manifest-first handoff root. |
 | Airflow DAG/config files | Prod | Read-only | DAG and config placement is explicit for this runtime. |
 | Monitoring configs | Prod | Read-only | Prometheus, Alertmanager, and Grafana provisioning remain versioned assets. |
 
@@ -200,10 +212,6 @@ The production-like Airflow config uses placeholder credentials where values are
 not safe to commit. Replace placeholders locally or use a future secret injection
 mechanism before running authenticated flows.
 
-Phase 8 hardening should reject placeholder values where they are unsafe for
-runtime behavior, while keeping documented local demo placeholders acceptable
-where they are explicitly non-sensitive.
-
 ## Validation checklist
 
 Minimum validation:
@@ -220,9 +228,3 @@ make dev-start
 make prod-start
 make prod-ps
 ```
-
-A dedicated production-like smoke validation target is tracked by Phase 8. It
-should eventually prove runner health, Airflow-to-runner communication, promoted
-manifest availability, API artifact metadata, API prediction serving from the
-promoted artifact, monitoring scrape availability, and the absence of Docker
-socket mounts in production-like Airflow.

--- a/docs/next-phase-design/artifact-handoff-strategy.md
+++ b/docs/next-phase-design/artifact-handoff-strategy.md
@@ -29,6 +29,34 @@ This hybrid decision keeps Phase 8 incremental. The project can validate the
 production-like runtime with local bind-mounted artifacts first, while keeping a
 stable contract that can later point to MinIO without changing every consumer.
 
+## Current coverage summary
+
+The Phase 8 foundation is now implemented, but the production-like execution path
+is not complete yet.
+
+Implemented:
+
+- strict artifact manifest models under `src/artifacts`;
+- local manifest store helpers with checksum verification and atomic
+  `current.json` replacement;
+- local manifest emission wrappers for ingest, features, and model jobs;
+- typed pipeline request and status contracts under `src/pipeline/contracts`;
+- production-like runtime mounts for generated data and artifact manifests;
+- production-like Airflow services without `/var/run/docker.sock`.
+
+Remaining before the Phase 8 goal is operational end-to-end:
+
+- internal `job-runner-api` skeleton;
+- runner execution of typed ML jobs;
+- production-like Airflow DAG path calling the runner;
+- API serving from promoted prediction manifests;
+- production-like smoke validation using realistic test fixtures;
+- configuration and placeholder hardening.
+
+The MinIO part is contract-compatible today through optional `s3://` object URIs.
+It is not yet a functional upload, download, verification, or primary serving
+backend.
+
 ## Source documents
 
 | Source | Use in this strategy |
@@ -141,6 +169,10 @@ s3://<bucket>/artifacts/<artifact_type>/<counter_id>/<run_id>/<file_name>
 Credentials, endpoint URLs, and access keys must remain runtime configuration and
 must not be embedded in manifests.
 
+Current limitation: object URIs are metadata only. Phase 8 does not yet implement
+artifact upload, download, checksum verification against object storage, or
+object-storage-first API serving.
+
 ## Identifier conventions
 
 | Field | Convention | Example |
@@ -248,15 +280,32 @@ keeps the API out of training job internals.
 | Make the API load the promoted local manifest. | #71 | Remaining | Future API implementation note. |
 | Add production-like smoke validation. | #72 | Remaining | Future smoke validation note. |
 | Harden runtime configuration and secrets validation. | #73 | Remaining | Future runtime hardening note. |
+| Strengthen realistic Phase 8 test coverage. | Follow-up technical debt | Remaining | Future test-fixture issue. |
 | Add optional MinIO upload/download helpers. | Later | Remaining | Future object-storage implementation note. |
 | Switch `primary_backend` to object storage. | Later | Deferred | Requires API and runner support first. |
+
+## Known technical and functional debt
+
+The remaining stories should not aim for a perfect production platform. They
+should leave explicit debt where Phase 8 deliberately stays incremental:
+
+- realistic integration fixtures derived from the real raw-data schema are still
+  needed;
+- unit coverage should be expanded for invalid manifests, runner state errors,
+  API manifest loading failures, and runtime configuration failures;
+- `current.json` discovery should stay explicit and counter-scoped so the API
+  does not reintroduce implicit latest-file scanning;
+- runner execution should stay typed and allow-listed, not a generic shell
+  command runner;
+- MinIO is not yet a functional artifact backend despite the optional
+  `object_uri` contract.
 
 ## Out of scope for the current implementation wave
 
 The current Phase 8 implementation wave does not implement:
 
-- runner API or worker execution;
-- Airflow DAG rewrites;
-- API serving from `current.json`;
-- MinIO upload/download helpers;
-- production secret management.
+- object-storage-first serving;
+- production secret management;
+- distributed runner queues;
+- remote deployment validation;
+- full performance or load testing.


### PR DESCRIPTION
## Summary

Prepare Phase 8 documentation before starting issue #68 by enforcing a stricter documentation boundary:

- `docs/current-runtime-and-operations/` describes the implemented runtime only.
- `docs/architecture-references/` describes implemented architecture only.
- `docs/next-phase-design/` owns target architecture, remaining Phase 8 tracking, and known debt.

## Changes

- Keep `local-prod-runtime.md` focused on current commands, workspaces, networks, mounts, exposure, and security exceptions.
- Keep `runtime-communication-matrix.md` focused on current service-to-service communication and current mount ownership.
- Move Phase 8 tracking and validation debt out of current-state docs and keep it in `next-phase-design/artifact-handoff-strategy.md`.
- Clarify that `docker/prod` is safer because Airflow has no Docker socket, but not yet fully executable through Airflow until the runner path is implemented.
- Clarify that MinIO support is currently contractual through optional `object_uri`, not yet a functional artifact backend.

## Documentation rule applied

Current docs describe what exists. Next-phase docs prepare what comes next.

This avoids mixing implementation status, target design, and backlog tracking in the same current-runtime documents before starting #68.

## Validation

Documentation-only change. Not run.