### PR TITLE
docs: clarify phase 8 minimal production target

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ one completed implementation slice.
 
 | Document | Purpose |
 | -------- | ------- |
+| [`next-phase-design/phase-8-production-minimal-target.md`](next-phase-design/phase-8-production-minimal-target.md) | Phase 8 closure target: minimal `docker/prod` execution path without Airflow Docker socket, using internal ML step services and manifest-first API serving. |
 | [`next-phase-design/artifact-handoff-strategy.md`](next-phase-design/artifact-handoff-strategy.md) | Consolidated manifest-first artifact handoff contract, implemented coverage, and open artifact-serving gaps. |
 | [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md) | Remaining production-like Airflow orchestration design that chains typed runner jobs. |
 
@@ -69,7 +70,8 @@ For runtime work, read:
 
 For active phase implementation, read:
 
-1. [`next-phase-design/artifact-handoff-strategy.md`](next-phase-design/artifact-handoff-strategy.md)
-2. [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md)
-3. [`architecture-references/local-prod-network-topology.md`](architecture-references/local-prod-network-topology.md)
-4. The GitHub issue for the current implementation task.
+1. [`next-phase-design/phase-8-production-minimal-target.md`](next-phase-design/phase-8-production-minimal-target.md)
+2. [`next-phase-design/artifact-handoff-strategy.md`](next-phase-design/artifact-handoff-strategy.md)
+3. [`next-phase-design/airflow-job-runner-strategy.md`](next-phase-design/airflow-job-runner-strategy.md)
+4. [`architecture-references/local-prod-network-topology.md`](architecture-references/local-prod-network-topology.md)
+5. The GitHub issue for the current implementation task.

--- a/docs/next-phase-design/phase-8-production-minimal-target.md
+++ b/docs/next-phase-design/phase-8-production-minimal-target.md
@@ -1,0 +1,92 @@
+# Phase 8 production minimal target
+
+This document coordinates the end-of-phase target for Phase 8. It is a
+`next-phase-design/` document: it describes the remaining implementation target,
+not the state already implemented on `main`.
+
+## Objective
+
+Make `docker/prod` minimally operational without an Airflow Docker socket, while
+progressively removing implicit local path discovery through a versioned local
+manifest that can reference either the production-like filesystem or, later,
+MinIO-compatible object storage.
+
+The end of Phase 8 should prove this minimal production-like path:
+
+```text
+Airflow DAG tasks
+  -> job-runner-api
+  -> ml-ingest-prod / ml-features-prod / ml-models-prod FastAPI services
+  -> promoted artifact manifests under docker/prod/runtime/artifacts
+  -> api-dev refresh and prediction serving from promoted manifests
+```
+
+## Target execution boundary
+
+Airflow remains the pipeline orchestrator. It chooses counters, dates, retries,
+and task dependencies.
+
+`job-runner-api` remains the narrow execution control boundary. It accepts one
+allow-listed typed step job at a time, records status, and maps failures to a
+structured `JobStatus`. It must not become a Docker SDK wrapper, a shell command
+runner, a durable queue, a worker pool, or a full-pipeline scheduler.
+
+The ML services own the concrete step execution:
+
+| Service | Target role | Required network scope |
+| ------- | ----------- | ---------------------- |
+| `ml-ingest-prod` | Execute one ingest request through the existing ingest CLI adapter and emit an interim dataset manifest. | `pipeline_runtime_net` |
+| `ml-features-prod` | Execute one feature request through the existing feature CLI adapter and emit a feature dataset manifest. | `pipeline_runtime_net` |
+| `ml-models-prod` | Execute one model request through the existing model CLI adapter, log MLflow evidence, and emit a prediction manifest. | `pipeline_runtime_net`, `tracking_client_net` |
+
+The runner calls these services through Compose DNS on `pipeline_runtime_net`.
+Airflow only calls the runner API and never asks Docker to start a container.
+
+## Manifest-first handoff
+
+The promoted manifest remains the release contract for served artifacts.
+Consumers must not rediscover the current prediction by scanning local folders or
+using implicit `latest` conventions.
+
+For the end of Phase 8:
+
+- `primary_backend="local"` remains the first functional backend;
+- local payloads stay under `docker/prod/runtime`;
+- `object_uri` can record optional `s3://` metadata;
+- MinIO upload, download, object checksum verification, and object-storage-first
+  API serving remain out of scope.
+
+## Story mapping
+
+| Issue | Scope |
+| ----- | ----- |
+| #70 | Add the ML step FastAPI services, switch the runner to HTTP service calls, and add the production-like Airflow DAG path. |
+| #71 | Make the prediction API manifest-aware and harden the runtime configuration needed by manifest serving. |
+| #72 | Add deterministic production-like smoke validation, realistic fixtures, negative-path checks, and final documentation cleanup. |
+
+Closed or removed Phase 8 configuration and test-debt stories are intentionally
+absorbed into those three implementation stories to keep the phase focused on one
+minimal operational production path.
+
+## Documentation movement rule
+
+While this target is not fully implemented, keep it in `next-phase-design/`.
+
+When each slice becomes stable:
+
+1. move implemented operation details to
+   `docs/current-runtime-and-operations/local-prod-runtime.md`;
+2. move implemented communication, network, and security boundaries to
+   `docs/architecture-references/`;
+3. keep only still-open gaps in `next-phase-design/`.
+
+## Out of scope for Phase 8 closure
+
+The Phase 8 closure target does not include:
+
+- object-storage-first serving;
+- production secret management;
+- distributed or durable runner queues;
+- Kubernetes or remote deployment validation;
+- full performance, load, or regression testing;
+- replacing the development DockerOperator path.


### PR DESCRIPTION
## Summary

- Add a focused Phase 8 target document for the minimal production-like runtime path.
- Clarify that the target path is Airflow -> job-runner-api -> internal ML step FastAPI services -> promoted manifests -> API serving.
- Update the documentation index and active-phase reading order.

## Scope

This is intentionally documentation-only. It keeps target behavior under `next-phase-design/` until implementation stories move stable wording to current runtime and architecture references.

## Related issues

- #70
- #71
- #72

## Validation

- Documentation-only change; no runtime validation required.