### PR TITLE
Fix #91 remove duplicated verify health endpoint

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -152,27 +152,6 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
             ).model_dump(),
         )
 
-    @app.get(
-        "/verify",
-        tags=["Admin"],
-        summary="Verify service health",
-        description="Simple service health check. [ADMIN ONLY]",
-        responses=GENERIC_RESPONSES,
-    )
-    def get_verify(
-        user_info: dict[str, str] = Depends(check_admin_role),
-    ) -> dict[str, str]:
-        """Health check restricted to administrators."""
-
-        LOGGER.info(
-            f"Health check requested by admin user: {user_info['username']}"
-        )
-        return {
-            "message": "API is healthy.",
-            "checked_by": user_info["username"],
-            "role": user_info["role"],
-        }
-
     @app.get("/health", tags=["Info"], responses=GENERIC_RESPONSES)
     def get_health() -> dict[str, str]:
         """Healthcheck endpoint used by Docker Compose."""

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -73,6 +73,28 @@ class TestApiAppFactory:
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
 
+    def test_openapi_schema_does_not_expose_verify_endpoint(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        client = TestClient(create_app(settings=_settings(tmp_path)))
+
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 200
+        assert "/health" in response.json()["paths"]
+        assert "/verify" not in response.json()["paths"]
+
+    def test_verify_endpoint_is_not_available(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        client = TestClient(create_app(settings=_settings(tmp_path)))
+
+        response = client.get("/verify", auth=("admin1", "admin1"))
+
+        assert response.status_code == 404
+
     def test_counters_returns_business_error_when_store_is_empty(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

- remove the duplicated admin-only `/verify` health endpoint
- keep `/health` as the single unauthenticated health check
- add API tests ensuring `/verify` is not exposed in OpenAPI and returns 404

## Validation

- Not run locally in this session; changes are limited to route removal and unit tests.

Closes #91