### PR TITLE
[STORY] Phase 9 - Enable bounded multi-counter parallel execution

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,6 +53,7 @@ MAILHOG_UI_HOST_PORT=15080
 AIRFLOW_IMAGE_NAME="apache/airflow:3.2.2-python3.12"
 AIRFLOW_POSTGRES_IMAGE="postgres:16"
 AIRFLOW_REDIS_IMAGE="redis:latest"
+NGINX_IMAGE="nginx:1.27-alpine"
 MLFLOW_IMAGE="ghcr.io/mlflow/mlflow:v3.13.0-full"
 MLFLOW_POSTGRES_IMAGE="postgres:16"
 MLFLOW_MINIO_IMAGE="minio/minio:RELEASE.2025-09-07T16-13-09Z"
@@ -63,6 +64,14 @@ PUSHGATEWAY_IMAGE="prom/pushgateway:v1.11.3"
 ALERTMANAGER_IMAGE="prom/alertmanager:v0.32.1"
 CADVISOR_IMAGE="gcr.io/cadvisor/cadvisor:v0.55.1"
 MAILHOG_IMAGE="mailhog/mailhog:latest"
+
+# ==============================================================================
+# Local production-like scale-out settings
+# ==============================================================================
+# Used by: make prod-scale-ml.
+ML_INGEST_REPLICAS=1
+ML_FEATURES_REPLICAS=1
+ML_MODELS_REPLICAS=1
 
 # ==============================================================================
 # Simulation variables

--- a/docker/prod/Makefile
+++ b/docker/prod/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 
 .PHONY: prod-help prod-prepare-runtime prod-compose-config prod-build
 .PHONY: prod-start prod-stop prod-down prod-ps prod-logs prod-clean
+.PHONY: prod-scale-ml
 
 DOCKER_COMPOSE ?= docker compose
 ENV_FILE ?= .env
@@ -11,6 +12,9 @@ PROD_COMPOSE_FILE ?= docker/prod/docker-compose.yaml
 PROD_PROFILE ?= ptf
 PROD_PROJECT_NAME ?= bike-traffic-prod
 SERVICE ?= api-dev
+ML_INGEST_REPLICAS ?= 1
+ML_FEATURES_REPLICAS ?= 1
+ML_MODELS_REPLICAS ?= 1
 
 prod_log_target = printf '==> [%s] \033[33m%s\033[0m\n' "$$(date --iso-8601=seconds)" "$(1)"
 prod_check_env = if [ ! -f "$(ENV_FILE)" ]; then echo "Error: $(ENV_FILE) is missing. Run: make env" >&2; exit 1; fi
@@ -56,6 +60,15 @@ prod-build: prod-prepare-runtime ## Build local production-like Docker images
 prod-start: prod-compose-config ## Start local production-like platform services
 	@$(call prod_log_target,prod-start PROD_PROFILE=$(PROD_PROFILE))
 	$(prod_compose) --profile $(PROD_PROFILE) up -d
+
+prod-scale-ml: prod-compose-config ## Scale ML replicas and reload gateway
+	@$(call prod_log_target,prod-scale-ml)
+	$(prod_compose) --profile all up -d \
+		--scale ml-ingest-prod=$(ML_INGEST_REPLICAS) \
+		--scale ml-features-prod=$(ML_FEATURES_REPLICAS) \
+		--scale ml-models-prod=$(ML_MODELS_REPLICAS) \
+		ml-ingest-prod ml-features-prod ml-models-prod ml-gateway
+	$(prod_compose) exec -T ml-gateway nginx -s reload
 
 prod-stop: ## Stop local production-like services for the selected profile
 	@$(call prod_log_target,prod-stop PROD_PROFILE=$(PROD_PROFILE))

--- a/docker/prod/airflow/config/bike_dag_config.json
+++ b/docker/prod/airflow/config/bike_dag_config.json
@@ -3,10 +3,16 @@
     "initial_anchor_date": "2025-09-12",
     "daily_increment_pct": 0.25
   },
+  "concurrency": {
+    "orchestrator_max_active_runs": 1,
+    "orchestrator_max_active_tasks": 2,
+    "child_max_active_runs": 2,
+    "child_max_active_tasks": 4
+  },
   "counters": {
     "Sebastopol_N-S_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de Sébastopol",
+      "site": "Totem 73 boulevard de Sebastopol",
       "orientation": "N-S",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",
@@ -21,7 +27,7 @@
     },
     "Sebastopol_S-N_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de Sébastopol",
+      "site": "Totem 73 boulevard de Sebastopol",
       "orientation": "S-N",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",

--- a/docker/prod/airflow/config/bike_dag_config.json
+++ b/docker/prod/airflow/config/bike_dag_config.json
@@ -12,7 +12,7 @@
   "counters": {
     "Sebastopol_N-S_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de Sebastopol",
+      "site": "Totem 73 boulevard de S\u00e9bastopol",
       "orientation": "N-S",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",
@@ -27,7 +27,7 @@
     },
     "Sebastopol_S-N_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de Sebastopol",
+      "site": "Totem 73 boulevard de S\u00e9bastopol",
       "orientation": "S-N",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",

--- a/docker/prod/airflow/config/bike_dag_config.json
+++ b/docker/prod/airflow/config/bike_dag_config.json
@@ -12,7 +12,7 @@
   "counters": {
     "Sebastopol_N-S_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de S\u00e9bastopol",
+      "site": "Totem 73 boulevard de Sébastopol",
       "orientation": "N-S",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",
@@ -27,7 +27,7 @@
     },
     "Sebastopol_S-N_airflow": {
       "raw_file_name": "comptage-velo-donnees-compteurs-2024-2025_Enriched_ML-ready_data.csv",
-      "site": "Totem 73 boulevard de S\u00e9bastopol",
+      "site": "Totem 73 boulevard de Sébastopol",
       "orientation": "S-N",
       "interim_name": "initial_airflow.csv",
       "processed_name": "initial_airflow_with_feats.csv",

--- a/docker/prod/airflow/dags/bike_traffic_orchestrator_dag.py
+++ b/docker/prod/airflow/dags/bike_traffic_orchestrator_dag.py
@@ -8,9 +8,10 @@ from datetime import datetime
 from airflow import DAG
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
-from common.utils import _list_counters_payload
+from common.utils import _list_counters_payload, _load_concurrency_config
 
 logger = logging.getLogger("airflow.task")
+concurrency = _load_concurrency_config()
 
 with DAG(
     dag_id="bike_traffic_orchestrator",
@@ -18,8 +19,8 @@ with DAG(
     start_date=datetime(2025, 9, 20),
     schedule="@daily",
     catchup=False,
-    max_active_runs=1,
-    max_active_tasks=1,
+    max_active_runs=concurrency.orchestrator_max_active_runs,
+    max_active_tasks=concurrency.orchestrator_max_active_tasks,
     tags=["ops", "orchestration", "bike", "prod"],
 ) as dag:
     logger.info("[orchestrator] Production-like DAG loaded")

--- a/docker/prod/airflow/dags/bike_traffic_pipeline_dag.py
+++ b/docker/prod/airflow/dags/bike_traffic_pipeline_dag.py
@@ -20,9 +20,10 @@ from airflow.providers.standard.operators.python import (
     ShortCircuitOperator,
 )
 from airflow.sdk import DAG, Param, TaskGroup, Variable
-from common.utils import CounterCfg, _load_config
+from common.utils import CounterCfg, _load_concurrency_config, _load_config
 
 logger = logging.getLogger("airflow.task")
+concurrency = _load_concurrency_config()
 
 JOB_RUNNER_URL = "http://job-runner-api:10080"
 DATA_ROOT = "/app/data"
@@ -37,6 +38,7 @@ DAG_PARAMS: ParamsDict = ParamsDict(
         )
     }
 )
+
 
 def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
     request = urllib.request.Request(
@@ -353,8 +355,8 @@ with DAG(
     start_date=datetime(2025, 9, 1),
     schedule=None,
     catchup=False,
-    max_active_runs=1,
-    max_active_tasks=1,
+    max_active_runs=concurrency.child_max_active_runs,
+    max_active_tasks=concurrency.child_max_active_tasks,
     tags=["mlops", "init", "bike", "prod"],
     params=DAG_PARAMS,
 ) as init_dag:
@@ -377,8 +379,8 @@ with DAG(
     start_date=datetime(2025, 9, 1),
     schedule=None,
     catchup=False,
-    max_active_runs=1,
-    max_active_tasks=1,
+    max_active_runs=concurrency.child_max_active_runs,
+    max_active_tasks=concurrency.child_max_active_tasks,
     tags=["mlops", "daily", "bike", "prod"],
     params=DAG_PARAMS,
 ) as daily_dag:

--- a/docker/prod/airflow/dags/common/utils.py
+++ b/docker/prod/airflow/dags/common/utils.py
@@ -41,11 +41,21 @@ class SchedulingCfg(BaseModel):
     daily_increment_pct: float
 
 
+class ConcurrencyCfg(BaseModel):
+    """Bounded local production-like Airflow concurrency limits."""
+
+    orchestrator_max_active_runs: int = Field(default=1, ge=1)
+    orchestrator_max_active_tasks: int = Field(default=2, ge=1)
+    child_max_active_runs: int = Field(default=2, ge=1)
+    child_max_active_tasks: int = Field(default=4, ge=1)
+
+
 class DagCfg(BaseModel):
     """Top-level DAG configuration."""
 
     counters: dict[str, CounterCfg]
     scheduling: SchedulingCfg
+    concurrency: ConcurrencyCfg = Field(default_factory=ConcurrencyCfg)
 
 
 def _load_config() -> tuple[DagCfg, str]:
@@ -65,6 +75,13 @@ def _load_config() -> tuple[DagCfg, str]:
         default_counter_id,
     )
     return cfg, default_counter_id
+
+
+def _load_concurrency_config() -> ConcurrencyCfg:
+    """Load only the bounded Airflow concurrency configuration."""
+
+    cfg, _ = _load_config()
+    return cfg.concurrency
 
 
 def _read_config_source(cfg_ref: str) -> str:

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -190,7 +190,7 @@ services:
     profiles: ["ml", "all", "ptf"]
 
   ml-gateway:
-    image: ${NGINX_IMAGE:-nginx:1.27-alpine}
+    image: ${NGINX_IMAGE:?required}
     restart: unless-stopped
     depends_on:
       ml-ingest-prod:

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -112,10 +112,10 @@ services:
       test:
         - CMD-SHELL
         - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10081/health', timeout=5).read()"
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 15s
+      start_period: 5s
     networks:
       - pipeline_runtime_net
       - observability_net
@@ -145,10 +145,10 @@ services:
       test:
         - CMD-SHELL
         - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10082/health', timeout=5).read()"
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 15s
+      start_period: 5s
     networks:
       - pipeline_runtime_net
       - observability_net
@@ -184,10 +184,10 @@ services:
       test:
         - CMD-SHELL
         - python -c "import urllib.request; urllib.request.urlopen('http://localhost:10083/health', timeout=5).read()"
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 15s
+      start_period: 5s
     networks:
       - pipeline_runtime_net
       - tracking_client_net

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -333,13 +333,17 @@ services:
     environment:
       MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
       MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
-      MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?required}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?required}
+      AWS_DEFAULT_REGION: us-east-1
+      GIT_PYTHON_REFRESH: quiet
+      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
     ports:
-      - "${MLFLOW_HOST_PORT:-15000}:5000"
+      - "${MLFLOW_HOST_PORT:-13001}:5000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health', timeout=5).read()"
       interval: 10s
       timeout: 5s
       retries: 5
@@ -363,10 +367,10 @@ services:
     volumes:
       - prod-airflow-postgres-db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${AIRFLOW_POSTGRES_USER:?required}"]
+      test: ["CMD", "pg_isready", "-U", "${AIRFLOW_POSTGRES_USER:?required}"]
       interval: 10s
-      timeout: 5s
       retries: 5
+      start_period: 15s
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
@@ -374,140 +378,163 @@ services:
   airflow-redis:
     image: ${AIRFLOW_REDIS_IMAGE:?required}
     restart: unless-stopped
-    expose:
-      - 6379
+    volumes:
+      - prod-airflow-redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
-    volumes:
-      - prod-airflow-redis-data:/data
+      start_period: 15s
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-init:
     <<: *airflow-common
-    command:
-      - bash
-      - -c
-      - |
-        set -euo pipefail
-        echo "Initializing production-like Airflow metadata database"
-        airflow db migrate
-        echo "Importing production-like Airflow connections"
-        airflow connections import /opt/airflow/config/connections.json
-        echo "Cleaning obsolete DockerOperator variables"
-        airflow variables delete docker_network || true
-        airflow variables delete ingestion_image || true
-        airflow variables delete features_image || true
-        airflow variables delete model_image || true
-        echo "Airflow initialization complete"
-    depends_on: *airflow-common-depends-on
+    restart: "no"
+    environment:
+      <<: *airflow-common-env
+    command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
     volumes:
-      - ./runtime/logs/airflow:/opt/airflow/logs
-      - ./runtime/data:/opt/airflow/data
-      - ./runtime/artifacts:/app/artifacts:ro
-      - ./airflow/dags:/opt/airflow/dags:ro
-      - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
-      - ./airflow/config/connections.json:/opt/airflow/config/connections.json:ro
+      - ./airflow/config/:/opt/airflow/config/:ro
+      - ./airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
     profiles: ["all", "airflow", "ptf"]
 
   airflow-api-server:
     <<: *airflow-common
-    command: api-server
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["api-server"]
     ports:
-      - "${AIRFLOW_API_HOST_PORT:-18080}:8080"
+      - "${AIRFLOW_HOST_PORT:-12080}:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
+      interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
 
   airflow-scheduler:
     <<: *airflow-common
-    command: scheduler
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["scheduler"]
     healthcheck:
-      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
 
   airflow-dag-processor:
     <<: *airflow-common
-    command: dag-processor
-
-  airflow-triggerer:
-    <<: *airflow-common
-    command: triggerer
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["dag-processor"]
     healthcheck:
-      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $(hostname)"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD-SHELL", "airflow jobs check --job-type DagProcessorJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
 
   airflow-worker:
     <<: *airflow-common
-    command: celery worker
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["celery", "worker"]
+    environment:
+      <<: *airflow-common-env
+    healthcheck:
+      test: ["CMD-SHELL", "celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - orchestration_net
       - pipeline_runtime_net
       - dev_support_net
+    profiles: ["all", "airflow", "ptf"]
+
+  airflow-triggerer:
+    <<: *airflow-common
+    restart: unless-stopped
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["triggerer"]
     healthcheck:
-      test:
-        - CMD-SHELL
-        - celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"
-      interval: 30s
-      timeout: 10s
+      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $${HOSTNAME}"]
+      interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 15s
+    profiles: ["all", "airflow", "ptf"]
 
   # ========================
-  # OBSERVABILITY SERVICES
+  # MONITORING SERVICES
   # ========================
   monitoring-prometheus:
     image: ${PROMETHEUS_IMAGE:?required}
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
-      - --web.enable-lifecycle
+      - --storage.tsdb.retention.time=15d
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus:/etc/prometheus:ro
       - prod-prometheus-data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - observability_net
-    profiles: ["all", "monitoring", "ptf"]
+    profiles: ["monitoring", "all", "ptf"]
 
   monitoring-grafana:
     image: ${GRAFANA_IMAGE:?required}
     restart: unless-stopped
-    ports:
-      - "${GRAFANA_HOST_PORT:-13000}:3000"
+    depends_on:
+      - monitoring-prometheus
     environment:
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?required}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?required}
-      GF_USERS_ALLOW_SIGN_UP: "false"
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "${GRAFANA_HOST_PORT:-14300}:3000"
     volumes:
       - prod-grafana-data:/var/lib/grafana
-      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - observability_net
-    profiles: ["all", "monitoring", "ptf"]
-
-  monitoring-pushgateway:
-    image: ${PUSHGATEWAY_IMAGE:?required}
-    restart: unless-stopped
-    expose:
-      - 9091
-    networks:
-      - pipeline_runtime_net
-      - observability_net
-    profiles: ["all", "monitoring", "ptf"]
+    profiles: ["monitoring", "all", "ptf"]
 
   monitoring-cadvisor:
     image: ${CADVISOR_IMAGE:?required}
@@ -517,18 +544,43 @@ services:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
       - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - observability_net
-    profiles: ["all", "monitoring", "ptf"]
+    profiles: ["monitoring", "all", "ptf"]
+
+  monitoring-pushgateway:
+    image: ${PUSHGATEWAY_IMAGE:?required}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - pipeline_runtime_net
+      - observability_net
+    profiles: ["monitoring", "all", "ptf"]
 
   monitoring-alertmanager:
     image: ${ALERTMANAGER_IMAGE:?required}
     restart: unless-stopped
     volumes:
-      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - prod-alertmanager-data:/alertmanager
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - observability_net
       - dev_support_net
@@ -537,8 +589,12 @@ services:
   monitoring-mailhog:
     image: ${MAILHOG_IMAGE:?required}
     restart: unless-stopped
-    ports:
-      - "${MAILHOG_HOST_PORT:-18025}:8025"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - dev_support_net
     profiles: ["all", "monitoring", "ptf"]

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -208,7 +208,7 @@ services:
     volumes:
       - ./ml-gateway/nginx.conf:/etc/nginx/conf.d/ml-gateway.conf:ro
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:10090/health"]
+      test: ["CMD-SHELL", "wget -q --spider http://ml-gateway:10090/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -236,6 +236,7 @@ services:
     environment:
       JOB_RUNNER_EXECUTOR: service
       JOB_RUNNER_LOG_ROOT: /app/logs/job-runner
+      JOB_RUNNER_MAX_IN_FLIGHT_JOBS: "2"
       JOB_RUNNER_SERVICE_TIMEOUT_SECONDS: "3600"
       ML_INGEST_SERVICE_URL: http://ml-ingest-prod:10081
       ML_FEATURES_SERVICE_URL: http://ml-features-prod:10082
@@ -332,17 +333,13 @@ services:
     environment:
       MLFLOW_BACKEND_STORE_URI: postgresql://${MLFLOW_POSTGRES_USER:?required}:${MLFLOW_POSTGRES_PASSWORD:?required}@mlflow-postgres:5432/${MLFLOW_POSTGRES_DB:?required}
       MLFLOW_DEFAULT_ARTIFACT_ROOT: s3://mlflow/
+      MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?required}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?required}
-      AWS_DEFAULT_REGION: us-east-1
-      GIT_PYTHON_REFRESH: quiet
-      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
     ports:
-      - "${MLFLOW_HOST_PORT:-13001}:5000"
+      - "${MLFLOW_HOST_PORT:-15000}:5000"
     healthcheck:
-      test:
-        - CMD-SHELL
-        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health', timeout=5).read()"
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -366,10 +363,10 @@ services:
     volumes:
       - prod-airflow-postgres-db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${AIRFLOW_POSTGRES_USER:?required}"]
+      test: ["CMD-SHELL", "pg_isready -U ${AIRFLOW_POSTGRES_USER:?required}"]
       interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 15s
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
@@ -377,163 +374,140 @@ services:
   airflow-redis:
     image: ${AIRFLOW_REDIS_IMAGE:?required}
     restart: unless-stopped
-    volumes:
-      - prod-airflow-redis-data:/data
+    expose:
+      - 6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 15s
+    volumes:
+      - prod-airflow-redis-data:/data
     networks:
       - orchestration_net
     profiles: ["all", "airflow", "ptf"]
 
   airflow-init:
     <<: *airflow-common
-    restart: "no"
-    environment:
-      <<: *airflow-common-env
-    command: ["bash", "/opt/airflow/scripts/airflow-init.sh"]
+    command:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        echo "Initializing production-like Airflow metadata database"
+        airflow db migrate
+        echo "Importing production-like Airflow connections"
+        airflow connections import /opt/airflow/config/connections.json
+        echo "Cleaning obsolete DockerOperator variables"
+        airflow variables delete docker_network || true
+        airflow variables delete ingestion_image || true
+        airflow variables delete features_image || true
+        airflow variables delete model_image || true
+        echo "Airflow initialization complete"
+    depends_on: *airflow-common-depends-on
     volumes:
-      - ./airflow/config/:/opt/airflow/config/:ro
-      - ./airflow/scripts/airflow-init.sh:/opt/airflow/scripts/airflow-init.sh:ro
+      - ./runtime/logs/airflow:/opt/airflow/logs
+      - ./runtime/data:/opt/airflow/data
+      - ./runtime/artifacts:/app/artifacts:ro
+      - ./airflow/dags:/opt/airflow/dags:ro
+      - ./airflow/config/bike_dag_config.json:/opt/airflow/config/bike_dag_config.json:ro
+      - ./airflow/config/connections.json:/opt/airflow/config/connections.json:ro
     profiles: ["all", "airflow", "ptf"]
 
   airflow-api-server:
     <<: *airflow-common
-    restart: unless-stopped
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
-    command: ["api-server"]
+    command: api-server
     ports:
-      - "${AIRFLOW_HOST_PORT:-12080}:8080"
+      - "${AIRFLOW_API_HOST_PORT:-18080}:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
+      interval: 30s
+      timeout: 10s
       retries: 5
-      start_period: 15s
-    profiles: ["all", "airflow", "ptf"]
+      start_period: 30s
 
   airflow-scheduler:
     <<: *airflow-common
-    restart: unless-stopped
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
-    command: ["scheduler"]
+    command: scheduler
     healthcheck:
-      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $${HOSTNAME}"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD-SHELL", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"]
+      interval: 30s
+      timeout: 10s
       retries: 5
-      start_period: 15s
-    profiles: ["all", "airflow", "ptf"]
+      start_period: 30s
 
   airflow-dag-processor:
     <<: *airflow-common
-    restart: unless-stopped
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
-    command: ["dag-processor"]
+    command: dag-processor
+
+  airflow-triggerer:
+    <<: *airflow-common
+    command: triggerer
     healthcheck:
-      test: ["CMD-SHELL", "airflow jobs check --job-type DagProcessorJob --hostname $${HOSTNAME}"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $(hostname)"]
+      interval: 30s
+      timeout: 10s
       retries: 5
-      start_period: 15s
-    profiles: ["all", "airflow", "ptf"]
+      start_period: 30s
 
   airflow-worker:
     <<: *airflow-common
-    restart: unless-stopped
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
-    command: ["celery", "worker"]
-    environment:
-      <<: *airflow-common-env
-    healthcheck:
-      test: ["CMD-SHELL", "celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME} || celery --app airflow.executors.celery_executor.app inspect ping -d celery@$${HOSTNAME}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
+    command: celery worker
     networks:
       - orchestration_net
       - pipeline_runtime_net
       - dev_support_net
-    profiles: ["all", "airflow", "ptf"]
-
-  airflow-triggerer:
-    <<: *airflow-common
-    restart: unless-stopped
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
-    command: ["triggerer"]
     healthcheck:
-      test: ["CMD-SHELL", "airflow jobs check --job-type TriggererJob --hostname $${HOSTNAME}"]
-      interval: 10s
-      timeout: 5s
+      test:
+        - CMD-SHELL
+        - celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"
+      interval: 30s
+      timeout: 10s
       retries: 5
-      start_period: 15s
-    profiles: ["all", "airflow", "ptf"]
+      start_period: 30s
 
   # ========================
-  # MONITORING SERVICES
+  # OBSERVABILITY SERVICES
   # ========================
   monitoring-prometheus:
     image: ${PROMETHEUS_IMAGE:?required}
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.retention.time=15d
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
     volumes:
-      - ./prometheus:/etc/prometheus:ro
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prod-prometheus-data:/prometheus
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
     networks:
       - observability_net
-    profiles: ["monitoring", "all", "ptf"]
+    profiles: ["all", "monitoring", "ptf"]
 
   monitoring-grafana:
     image: ${GRAFANA_IMAGE:?required}
     restart: unless-stopped
-    depends_on:
-      - monitoring-prometheus
-    environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
-      - GF_USERS_ALLOW_SIGN_UP=false
     ports:
-      - "${GRAFANA_HOST_PORT:-14300}:3000"
+      - "${GRAFANA_HOST_PORT:-13000}:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?required}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?required}
+      GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - prod-grafana-data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
+      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
     networks:
       - observability_net
-    profiles: ["monitoring", "all", "ptf"]
+    profiles: ["all", "monitoring", "ptf"]
+
+  monitoring-pushgateway:
+    image: ${PUSHGATEWAY_IMAGE:?required}
+    restart: unless-stopped
+    expose:
+      - 9091
+    networks:
+      - pipeline_runtime_net
+      - observability_net
+    profiles: ["all", "monitoring", "ptf"]
 
   monitoring-cadvisor:
     image: ${CADVISOR_IMAGE:?required}
@@ -543,43 +517,18 @@ services:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
       - /sys:/sys:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/healthz"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
     networks:
       - observability_net
-    profiles: ["monitoring", "all", "ptf"]
-
-  monitoring-pushgateway:
-    image: ${PUSHGATEWAY_IMAGE:?required}
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/-/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
-    networks:
-      - pipeline_runtime_net
-      - observability_net
-    profiles: ["monitoring", "all", "ptf"]
+    profiles: ["all", "monitoring", "ptf"]
 
   monitoring-alertmanager:
     image: ${ALERTMANAGER_IMAGE:?required}
     restart: unless-stopped
     volumes:
-      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - prod-alertmanager-data:/alertmanager
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
     networks:
       - observability_net
       - dev_support_net
@@ -588,12 +537,8 @@ services:
   monitoring-mailhog:
     image: ${MAILHOG_IMAGE:?required}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
+    ports:
+      - "${MAILHOG_HOST_PORT:-18025}:8025"
     networks:
       - dev_support_net
     profiles: ["all", "monitoring", "ptf"]

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -189,6 +189,28 @@ services:
       - observability_net
     profiles: ["ml", "all", "ptf"]
 
+  ml-gateway:
+    image: ${NGINX_IMAGE:-nginx:1.27-alpine}
+    restart: unless-stopped
+    depends_on:
+      ml-ingest-prod:
+        condition: service_healthy
+      ml-features-prod:
+        condition: service_healthy
+      ml-models-prod:
+        condition: service_healthy
+    volumes:
+      - ./ml-gateway/nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:10090/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pipeline_runtime_net
+    profiles: ["ml", "all", "ptf"]
+
   api-prod:
     <<: *prod-security
     image: api:prod
@@ -227,20 +249,16 @@ services:
       dockerfile: ./docker/prod/job-runner/Dockerfile
     restart: unless-stopped
     depends_on:
-      ml-ingest-prod:
-        condition: service_healthy
-      ml-features-prod:
-        condition: service_healthy
-      ml-models-prod:
+      ml-gateway:
         condition: service_healthy
     environment:
       JOB_RUNNER_EXECUTOR: service
       JOB_RUNNER_LOG_ROOT: /app/logs/job-runner
       JOB_RUNNER_MAX_IN_FLIGHT_JOBS: "2"
       JOB_RUNNER_SERVICE_TIMEOUT_SECONDS: "3600"
-      ML_INGEST_SERVICE_URL: http://ml-ingest-prod:10081
-      ML_FEATURES_SERVICE_URL: http://ml-features-prod:10082
-      ML_MODELS_SERVICE_URL: http://ml-models-prod:10083
+      ML_INGEST_SERVICE_URL: http://ml-gateway:10090/ingest
+      ML_FEATURES_SERVICE_URL: http://ml-gateway:10090/features
+      ML_MODELS_SERVICE_URL: http://ml-gateway:10090/models
     volumes:
       - ./runtime/logs/job-runner:/app/logs/job-runner
     healthcheck:

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -95,6 +95,8 @@ services:
       context: ../..
       dockerfile: ./docker/prod/ml/ingest/Dockerfile
     restart: unless-stopped
+    deploy:
+      replicas: ${ML_INGEST_REPLICAS:?required}
     environment:
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR:?required}
       DISABLE_METRICS_PUSH: 0
@@ -126,6 +128,8 @@ services:
       context: ../..
       dockerfile: ./docker/prod/ml/features/Dockerfile
     restart: unless-stopped
+    deploy:
+      replicas: ${ML_FEATURES_REPLICAS:?required}
     environment:
       PUSHGATEWAY_ADDR: ${PUSHGATEWAY_ADDR:?required}
       DISABLE_METRICS_PUSH: 0
@@ -157,6 +161,8 @@ services:
       context: ../..
       dockerfile: ./docker/prod/ml/models/Dockerfile
     restart: unless-stopped
+    deploy:
+      replicas: ${ML_MODELS_REPLICAS:?required}
     environment:
       MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
       MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
@@ -200,7 +206,7 @@ services:
       ml-models-prod:
         condition: service_healthy
     volumes:
-      - ./ml-gateway/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ml-gateway/nginx.conf:/etc/nginx/conf.d/ml-gateway.conf:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:10090/health"]
       interval: 10s

--- a/docker/prod/ml-gateway/nginx.conf
+++ b/docker/prod/ml-gateway/nginx.conf
@@ -1,0 +1,53 @@
+worker_processes 1;
+
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    resolver 127.0.0.11 valid=5s ipv6=off;
+
+    upstream ml_ingest_backend {
+        zone ml_ingest_backend 64k;
+        server ml-ingest-prod:10081 resolve;
+    }
+
+    upstream ml_features_backend {
+        zone ml_features_backend 64k;
+        server ml-features-prod:10082 resolve;
+    }
+
+    upstream ml_models_backend {
+        zone ml_models_backend 64k;
+        server ml-models-prod:10083 resolve;
+    }
+
+    server {
+        listen 10090;
+        server_name ml-gateway;
+
+        proxy_http_version 1.1;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+
+        location = /health {
+            add_header Content-Type text/plain;
+            return 200 "healthy\n";
+        }
+
+        location = /ingest/jobs {
+            proxy_pass http://ml_ingest_backend/jobs;
+        }
+
+        location = /features/jobs {
+            proxy_pass http://ml_features_backend/jobs;
+        }
+
+        location = /models/jobs {
+            proxy_pass http://ml_models_backend/jobs;
+        }
+    }
+}

--- a/docker/prod/ml-gateway/nginx.conf
+++ b/docker/prod/ml-gateway/nginx.conf
@@ -1,53 +1,31 @@
-worker_processes 1;
+resolver 127.0.0.11 valid=5s ipv6=off;
 
-pid /tmp/nginx.pid;
+server {
+    listen 10090;
+    server_name ml-gateway;
 
-events {
-    worker_connections 1024;
-}
+    proxy_http_version 1.1;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 3600s;
+    proxy_read_timeout 3600s;
 
-http {
-    resolver 127.0.0.11 valid=5s ipv6=off;
-
-    upstream ml_ingest_backend {
-        zone ml_ingest_backend 64k;
-        server ml-ingest-prod:10081 resolve;
+    location = /health {
+        add_header Content-Type text/plain;
+        return 200 "healthy\n";
     }
 
-    upstream ml_features_backend {
-        zone ml_features_backend 64k;
-        server ml-features-prod:10082 resolve;
+    location = /ingest/jobs {
+        set $ml_backend "ml-ingest-prod:10081";
+        proxy_pass http://$ml_backend/jobs;
     }
 
-    upstream ml_models_backend {
-        zone ml_models_backend 64k;
-        server ml-models-prod:10083 resolve;
+    location = /features/jobs {
+        set $ml_backend "ml-features-prod:10082";
+        proxy_pass http://$ml_backend/jobs;
     }
 
-    server {
-        listen 10090;
-        server_name ml-gateway;
-
-        proxy_http_version 1.1;
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 3600s;
-        proxy_read_timeout 3600s;
-
-        location = /health {
-            add_header Content-Type text/plain;
-            return 200 "healthy\n";
-        }
-
-        location = /ingest/jobs {
-            proxy_pass http://ml_ingest_backend/jobs;
-        }
-
-        location = /features/jobs {
-            proxy_pass http://ml_features_backend/jobs;
-        }
-
-        location = /models/jobs {
-            proxy_pass http://ml_models_backend/jobs;
-        }
+    location = /models/jobs {
+        set $ml_backend "ml-models-prod:10083";
+        proxy_pass http://$ml_backend/jobs;
     }
 }

--- a/docs/current-runtime-and-operations/dependency-strategy.md
+++ b/docs/current-runtime-and-operations/dependency-strategy.md
@@ -79,12 +79,10 @@ local developer ergonomics and for tools such as the VS Code Docker extension.
 
 | Service family | Current image policy |
 | -------------- | -------------------- |
-| Orchestration services | Uses Airflow, PostgreSQL, and Redis images. |
+| Orchestration services | Uses NGinx, Airflow, PostgreSQL, and Redis images. |
 | Experimentation services | Uses MLflow, PostgreSQL, MinIO, and MC images. |
-| Internal ML gateway | Uses the required `NGINX_IMAGE` variable for prod-like runner-to-ML routing. |
 | Monitoring services | Uses Prometheus, Grafana, Pushgateway, Alertmanager, and cAdvisor images. |
 | Development helpers | Uses MailHog images. |
-| Custom FastAPI services | Uses Python 3.12 slim images with pinned FastAPI and uvicorn dependencies. |
 
 ## Healthchecks
 
@@ -96,28 +94,28 @@ it is part of the image.
 | ------- | -------------------- |
 | `api-dev` | Python `urllib` read check on `/docs`. |
 | `job-runner-api` | Python `urllib` read check on `/health`. |
-| `ml-gateway` | Nginx `wget` check on `http://ml-gateway:10090/health` through Compose DNS. |
+| `ml-gateway` | `wget` check on `/health`. |
 | `mlflow-postgres` | `pg_isready` against the MLflow metadata database. |
-| `mlflow-minio` | curl check on `/minio/health/live`. |
+| `mlflow-minio` | `curl` check on `/minio/health/live`. |
 | `mlflow-server` | Python `urllib` read check on `/health`. |
 | `airflow-postgres` | `pg_isready` against the Airflow metadata database. |
 | `airflow-redis` | `redis-cli ping`. |
-| `airflow-api-server` | curl check on `/api/v2/monitor/health`. |
+| `airflow-api-server` | `curl` check on `/api/v2/monitor/health`. |
 | `airflow-scheduler` | `airflow jobs check --job-type SchedulerJob`. |
 | `airflow-dag-processor` | `airflow jobs check --job-type DagProcessorJob`. |
 | `airflow-worker` | Celery ping. The dev worker executes the check as the `airflow` user because its entrypoint starts as root only to adjust Docker socket access. |
 | `airflow-triggerer` | `airflow jobs check --job-type TriggererJob`. |
-| `airflow-flower` | curl check on `/` in the dev runtime. |
-| `monitoring-prometheus` | wget check on `/-/ready`. |
-| `monitoring-grafana` | wget check on `/api/health`. |
-| `monitoring-pushgateway` | wget check on `/-/ready`. |
-| `monitoring-alertmanager` | wget check on `/-/ready`. |
-| `monitoring-cadvisor` | wget check on `/healthz`. |
-| `monitoring-mailhog` | wget check on `/`. |
+| `airflow-flower` | `curl` check on `/` in the dev runtime. |
+| `monitoring-prometheus` | `wget` check on `/-/ready`. |
+| `monitoring-grafana` | `wget` check on `/api/health`. |
+| `monitoring-pushgateway` | `wget` check on `/-/ready`. |
+| `monitoring-alertmanager` | `wget` check on `/-/ready`. |
+| `monitoring-cadvisor` | `wget` check on `/healthz`. |
+| `monitoring-mailhog` | `wget` check on `/`. |
 
 ## Runtime-sensitive dependencies
 
-The following dependencies are runtime-sensitive and should not be upgraded as a
+The following dependencies are runtime-sensitive onboarded within custom images and should not be upgraded as a
 bulk maintenance action:
 
 - `pandas`
@@ -129,12 +127,6 @@ bulk maintenance action:
 - `mlflow`
 - `prometheus-client`
 - `prometheus-fastapi-instrumentator`
-- Airflow image versions
-- Nginx gateway image version
-- monitoring runtime images
-
-Runtime-sensitive upgrades must be isolated and validated with a dedicated PR or
-explicit validation section.
 
 ## Compatibility checks
 
@@ -155,25 +147,6 @@ FastAPI compatibility checks should include:
 - response model serialization;
 - healthcheck endpoint availability.
 
-Gateway compatibility checks should include:
-
-- `ml-gateway` healthcheck availability on `pipeline_runtime_net`;
-- typed `/ingest/jobs`, `/features/jobs`, and `/models/jobs` routing;
-- Compose scale-up and scale-down with Nginx reload;
-- no host-published gateway port in the production-like runtime.
-
-Monitoring runtime changes should validate at least:
-
-- Prometheus configuration parsing;
-- Prometheus targets under `/targets`;
-- API metrics scraping;
-- Pushgateway scraping;
-- cAdvisor scraping;
-- Grafana datasource provisioning;
-- Grafana dashboard loading;
-- Alertmanager configuration loading;
-- MailHog alert notification capture when alert routing is tested.
-
 ## Regression checklist for runtime dependency changes
 
 Before merging a runtime dependency upgrade, validate at least:
@@ -182,32 +155,22 @@ Before merging a runtime dependency upgrade, validate at least:
 make sync
 make lint
 make tests
-make dev-compose-config
 make prod-compose-config
-make dev-build
 make prod-build
-make dev-start DEV_PROFILE=ptf
 make prod-start PROD_PROFILE=ptf
 make prod-scale-ml ML_INGEST_REPLICAS=2 ML_FEATURES_REPLICAS=2 ML_MODELS_REPLICAS=2
-make dev-mlops-pipeline
-make dev-logs SERVICE=api-dev
+make acceptance
 ```
 
 Then verify:
 
+- Docker Compose services start without dependency resolution errors.
 - prediction files are produced under root `data/final` for the development runtime;
 - production-like generated artifacts stay under `docker/prod/runtime`;
-- model artifacts are produced under root `models` for the development runtime;
 - MLflow runs contain expected parameters, metrics, and artifacts;
-- API `/docs` is reachable;
-- job runner API `/health` is reachable inside `docker/prod`;
-- `ml-gateway` is healthy and reloads after ML service scaling;
 - API prediction endpoints still return the expected schema;
-- Prometheus targets are healthy and ML/API metrics are visible;
 - Grafana starts and loads the provisioned Prometheus datasource;
 - Grafana dashboards load with current Prometheus metrics;
-- Prometheus metrics are not pushed during local tests when `DISABLE_METRICS_PUSH=1`;
-- Docker Compose services start without dependency resolution errors.
 
 ## Upgrade policy
 

--- a/docs/current-runtime-and-operations/dependency-strategy.md
+++ b/docs/current-runtime-and-operations/dependency-strategy.md
@@ -63,6 +63,7 @@ local developer ergonomics and for tools such as the VS Code Docker extension.
 | `AIRFLOW_IMAGE_NAME` | `apache/airflow:3.2.2-python3.12` | `sha256:bbe58e3204d550ab98dbf738a42c0e6663c455357ecd0e2d1440ef9cb6a75f00` |
 | `AIRFLOW_POSTGRES_IMAGE` | `postgres:16` | `sha256:4b7183ac05f8ef417db21fd72d71047a4238340c261d3cc3ddb6d579ab5071ae` |
 | `AIRFLOW_REDIS_IMAGE` | `redis:latest` | `sha256:aa049e689e141a4358ad1d4562dc49c88a89fbab711fd8fcc33f684c80b26301` |
+| `NGINX_IMAGE` | `nginx:1.27-alpine` | `sha256:6769dc3a703c719c1d2756bda113659be28ae16cf0da58dd5fd823d6b9a050ea` |
 | `MLFLOW_IMAGE` | `ghcr.io/mlflow/mlflow:v3.13.0-full` | `sha256:45bdcc9439dac5c51c160a863e3c1cadae1757de9d6d1b9403e0a648a6f2333b` |
 | `MLFLOW_POSTGRES_IMAGE` | `postgres:16` | `sha256:4b7183ac05f8ef417db21fd72d71047a4238340c261d3cc3ddb6d579ab5071ae` |
 | `MLFLOW_MINIO_IMAGE` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` | `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e` |
@@ -80,6 +81,7 @@ local developer ergonomics and for tools such as the VS Code Docker extension.
 | -------------- | -------------------- |
 | Orchestration services | Uses Airflow, PostgreSQL, and Redis images. |
 | Experimentation services | Uses MLflow, PostgreSQL, MinIO, and MC images. |
+| Internal ML gateway | Uses the required `NGINX_IMAGE` variable for prod-like runner-to-ML routing. |
 | Monitoring services | Uses Prometheus, Grafana, Pushgateway, Alertmanager, and cAdvisor images. |
 | Development helpers | Uses MailHog images. |
 | Custom FastAPI services | Uses Python 3.12 slim images with pinned FastAPI and uvicorn dependencies. |
@@ -94,6 +96,7 @@ it is part of the image.
 | ------- | -------------------- |
 | `api-dev` | Python `urllib` read check on `/docs`. |
 | `job-runner-api` | Python `urllib` read check on `/health`. |
+| `ml-gateway` | Nginx `wget` check on `http://ml-gateway:10090/health` through Compose DNS. |
 | `mlflow-postgres` | `pg_isready` against the MLflow metadata database. |
 | `mlflow-minio` | curl check on `/minio/health/live`. |
 | `mlflow-server` | Python `urllib` read check on `/health`. |
@@ -127,6 +130,7 @@ bulk maintenance action:
 - `prometheus-client`
 - `prometheus-fastapi-instrumentator`
 - Airflow image versions
+- Nginx gateway image version
 - monitoring runtime images
 
 Runtime-sensitive upgrades must be isolated and validated with a dedicated PR or
@@ -150,6 +154,13 @@ FastAPI compatibility checks should include:
 - request validation errors;
 - response model serialization;
 - healthcheck endpoint availability.
+
+Gateway compatibility checks should include:
+
+- `ml-gateway` healthcheck availability on `pipeline_runtime_net`;
+- typed `/ingest/jobs`, `/features/jobs`, and `/models/jobs` routing;
+- Compose scale-up and scale-down with Nginx reload;
+- no host-published gateway port in the production-like runtime.
 
 Monitoring runtime changes should validate at least:
 
@@ -177,6 +188,7 @@ make dev-build
 make prod-build
 make dev-start DEV_PROFILE=ptf
 make prod-start PROD_PROFILE=ptf
+make prod-scale-ml ML_INGEST_REPLICAS=2 ML_FEATURES_REPLICAS=2 ML_MODELS_REPLICAS=2
 make dev-mlops-pipeline
 make dev-logs SERVICE=api-dev
 ```
@@ -189,6 +201,7 @@ Then verify:
 - MLflow runs contain expected parameters, metrics, and artifacts;
 - API `/docs` is reachable;
 - job runner API `/health` is reachable inside `docker/prod`;
+- `ml-gateway` is healthy and reloads after ML service scaling;
 - API prediction endpoints still return the expected schema;
 - Prometheus targets are healthy and ML/API metrics are visible;
 - Grafana starts and loads the provisioned Prometheus datasource;

--- a/docs/current-runtime-and-operations/ports-and-services.md
+++ b/docs/current-runtime-and-operations/ports-and-services.md
@@ -85,6 +85,7 @@ The following service families are intentionally not published on host ports:
 | `ml-ingest-prod` | Prod-like | `10081` | Internal FastAPI ML step service for validated ingestion jobs. |
 | `ml-features-prod` | Prod-like | `10082` | Internal FastAPI ML step service for validated feature jobs. |
 | `ml-models-prod` | Prod-like | `10083` | Internal FastAPI ML step service for validated model jobs. |
+| `ml-gateway` | Prod-like | `10090` | Internal Nginx gateway between runner API and scaled ML step service replicas. |
 | `job-runner-api` | Prod-like | `10080` | Internal typed job submission and status boundary. |
 | `mlflow-postgres` | Dev and prod-like | `5432` | MLflow internal metadata database. |
 | `mlflow-mc-init` | Dev and prod-like | n/a | One-off MinIO initialization helper. |
@@ -117,6 +118,6 @@ make dev-build
 make prod-build
 ```
 
-`make prod-compose-config` should show `job-runner-api` without a `ports` block
-and should keep `ml-ingest-prod`, `ml-features-prod`, and `ml-models-prod`
-internal-only.
+`make prod-compose-config` should show `job-runner-api` and `ml-gateway` without
+`ports` blocks and should keep `ml-ingest-prod`, `ml-features-prod`, and
+`ml-models-prod` internal-only.

--- a/src/job_runner/executor.py
+++ b/src/job_runner/executor.py
@@ -16,7 +16,8 @@ from src.ml.jobs.status import JobResult, JobStatus
 
 MlJobExecutionError = MlStepExecutionError
 
-_RUNNER_SERVICE_LOCK = threading.Lock()
+JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV = "JOB_RUNNER_MAX_IN_FLIGHT_JOBS"
+DEFAULT_MAX_IN_FLIGHT_JOBS = 2
 
 
 class MlJobExecutor(Protocol):
@@ -38,19 +39,25 @@ class LocalMlJobExecutor(StepCommandExecutor):
 
 
 class ServiceMlJobExecutor:
-    """Execute one allow-listed ML step through internal ML service APIs."""
+    """Execute allow-listed ML steps through internal ML service APIs."""
 
     def __init__(
         self,
         transport: MlServiceTransport | None = None,
         endpoints: dict[MlJobType, str] | None = None,
-        lock: threading.Lock | None = None,
+        max_in_flight_jobs: int | None = None,
+        concurrency_limiter: threading.BoundedSemaphore | None = None,
     ) -> None:
         self._transport = transport or UrllibMlServiceTransport()
         self._endpoints = (
             endpoints if endpoints is not None else _load_service_endpoints()
         )
-        self._lock = lock or _RUNNER_SERVICE_LOCK
+        self.max_in_flight_jobs = _resolve_max_in_flight_jobs(
+            max_in_flight_jobs,
+        )
+        self._concurrency_limiter = concurrency_limiter or threading.BoundedSemaphore(
+            self.max_in_flight_jobs,
+        )
 
     def execute(
         self,
@@ -72,7 +79,7 @@ class ServiceMlJobExecutor:
                 retryable=False,
             )
 
-        with self._lock:
+        with self._concurrency_limiter:
             status = self._transport.submit(
                 endpoint=endpoint,
                 job_request=job_request,
@@ -168,6 +175,36 @@ def _load_service_endpoints() -> dict[MlJobType, str]:
             "http://ml-models-prod:10083",
         ),
     }
+
+
+def _resolve_max_in_flight_jobs(configured_value: int | None = None) -> int:
+    if configured_value is not None:
+        return _validate_positive_int(
+            configured_value,
+            name="max_in_flight_jobs",
+        )
+
+    raw_value = os.getenv(
+        JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV,
+        str(DEFAULT_MAX_IN_FLIGHT_JOBS),
+    )
+    try:
+        parsed_value = int(raw_value)
+    except ValueError as error:
+        raise ValueError(
+            f"{JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV} must be a positive integer."
+        ) from error
+
+    return _validate_positive_int(
+        parsed_value,
+        name=JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV,
+    )
+
+
+def _validate_positive_int(value: int, *, name: str) -> int:
+    if value < 1:
+        raise ValueError(f"{name} must be greater than or equal to 1.")
+    return value
 
 
 def _join_url(base_url: str, path: str) -> str:

--- a/tests/unit/job_runner/test_executor.py
+++ b/tests/unit/job_runner/test_executor.py
@@ -1,19 +1,24 @@
 # tests/job_runner/test_executor.py
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
-from threading import Lock
 from unittest.mock import Mock, patch
 from urllib.error import HTTPError, URLError
 
 import pytest
 
 from src.job_runner.executor import (
+    DEFAULT_MAX_IN_FLIGHT_JOBS,
+    JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV,
     MlJobExecutionError,
     ServiceMlJobExecutor,
     UrllibMlServiceTransport,
     _join_url,
     _json_bytes,
+    _resolve_max_in_flight_jobs,
 )
 from src.job_runner.service import build_default_executor
 from src.ml.jobs.contracts import IngestJobRequest
@@ -35,7 +40,7 @@ class TestServiceMlJobExecutor:
         executor = ServiceMlJobExecutor(
             transport=transport,
             endpoints={job_request.job_type: "http://ml-ingest:10081"},
-            lock=Lock(),
+            max_in_flight_jobs=1,
         )
 
         result = executor.execute(
@@ -58,7 +63,7 @@ class TestServiceMlJobExecutor:
         executor = ServiceMlJobExecutor(
             transport=Mock(),
             endpoints={},
-            lock=Lock(),
+            max_in_flight_jobs=1,
         )
 
         with pytest.raises(MlJobExecutionError) as exc_info:
@@ -86,7 +91,7 @@ class TestServiceMlJobExecutor:
         executor = ServiceMlJobExecutor(
             transport=transport,
             endpoints={job_request.job_type: "http://ml-ingest:10081"},
-            lock=Lock(),
+            max_in_flight_jobs=1,
         )
 
         with pytest.raises(MlJobExecutionError) as exc_info:
@@ -99,6 +104,125 @@ class TestServiceMlJobExecutor:
         assert exc_info.value.code == "INGEST_FAILED"
         assert exc_info.value.message == "raw file missing"
         assert exc_info.value.retryable is False
+
+    def test_execute_allows_bounded_parallel_service_dispatch(self) -> None:
+        job_request = _ingest_request()
+        first_call_started = threading.Event()
+        release_calls = threading.Event()
+        observed_in_flight = 0
+        max_observed_in_flight = 0
+        in_flight_lock = threading.Lock()
+
+        def submit(endpoint: str, job_request: IngestJobRequest) -> JobStatus:
+            nonlocal max_observed_in_flight
+            nonlocal observed_in_flight
+            assert endpoint == "http://ml-ingest:10081"
+            assert job_request.counter_id == "counter-a"
+            with in_flight_lock:
+                observed_in_flight += 1
+                max_observed_in_flight = max(
+                    max_observed_in_flight,
+                    observed_in_flight,
+                )
+                first_call_started.set()
+            release_calls.wait(timeout=5)
+            with in_flight_lock:
+                observed_in_flight -= 1
+            return _job_status(
+                job_id="service-job",
+                state=JobState.SUCCEEDED,
+                result=_job_result(job_id="service-job"),
+            )
+
+        transport = Mock()
+        transport.submit.side_effect = submit
+        executor = ServiceMlJobExecutor(
+            transport=transport,
+            endpoints={job_request.job_type: "http://ml-ingest:10081"},
+            max_in_flight_jobs=2,
+        )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(
+                executor.execute,
+                job_request,
+                job_id="runner-job-a",
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            assert first_call_started.wait(timeout=5)
+            second = pool.submit(
+                executor.execute,
+                job_request,
+                job_id="runner-job-b",
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            time.sleep(0.05)
+            release_calls.set()
+
+            assert first.result().job_id == "runner-job-a"
+            assert second.result().job_id == "runner-job-b"
+
+        assert max_observed_in_flight == 2
+
+    def test_execute_respects_configured_parallel_dispatch_limit(self) -> None:
+        job_request = _ingest_request()
+        first_call_started = threading.Event()
+        release_calls = threading.Event()
+        observed_in_flight = 0
+        max_observed_in_flight = 0
+        in_flight_lock = threading.Lock()
+
+        def submit(endpoint: str, job_request: IngestJobRequest) -> JobStatus:
+            nonlocal max_observed_in_flight
+            nonlocal observed_in_flight
+            assert endpoint == "http://ml-ingest:10081"
+            assert job_request.counter_id == "counter-a"
+            with in_flight_lock:
+                observed_in_flight += 1
+                max_observed_in_flight = max(
+                    max_observed_in_flight,
+                    observed_in_flight,
+                )
+                first_call_started.set()
+            release_calls.wait(timeout=5)
+            with in_flight_lock:
+                observed_in_flight -= 1
+            return _job_status(
+                job_id="service-job",
+                state=JobState.SUCCEEDED,
+                result=_job_result(job_id="service-job"),
+            )
+
+        transport = Mock()
+        transport.submit.side_effect = submit
+        executor = ServiceMlJobExecutor(
+            transport=transport,
+            endpoints={job_request.job_type: "http://ml-ingest:10081"},
+            max_in_flight_jobs=1,
+        )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(
+                executor.execute,
+                job_request,
+                job_id="runner-job-a",
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            assert first_call_started.wait(timeout=5)
+            second = pool.submit(
+                executor.execute,
+                job_request,
+                job_id="runner-job-b",
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            time.sleep(0.05)
+            assert max_observed_in_flight == 1
+            release_calls.set()
+
+            assert first.result().job_id == "runner-job-a"
+            assert second.result().job_id == "runner-job-b"
+
+        assert max_observed_in_flight == 1
 
 
 class TestUrllibMlServiceTransport:
@@ -186,6 +310,26 @@ class TestRunnerExecutorConfiguration:
             build_default_executor()
 
         assert "JOB_RUNNER_EXECUTOR" in str(exc_info.value)
+
+    def test_default_max_in_flight_jobs_is_conservative(self) -> None:
+        assert DEFAULT_MAX_IN_FLIGHT_JOBS == 2
+
+    def test_resolve_max_in_flight_jobs_reads_environment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV, "3")
+
+        assert _resolve_max_in_flight_jobs() == 3
+
+    def test_resolve_max_in_flight_jobs_rejects_invalid_environment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV, "0")
+
+        with pytest.raises(ValueError, match=JOB_RUNNER_MAX_IN_FLIGHT_JOBS_ENV):
+            _resolve_max_in_flight_jobs()
 
 
 def test_join_url_normalizes_slashes() -> None:


### PR DESCRIPTION
## Summary

Implements the bounded local production-like execution slice for Phase 9.

- Add explicit Airflow concurrency settings to `bike_dag_config.json`.
- Wire the prod orchestrator DAG to configured parent run/task limits.
- Wire prod init/daily child DAGs to configured child run/task limits.
- Replace the runner service global lock with a bounded semaphore controlled by `JOB_RUNNER_MAX_IN_FLIGHT_JOBS`.
- Add an internal `ml-gateway` Nginx service on `pipeline_runtime_net` between `job-runner-api` and the ML step services.
- Route typed runner calls through gateway paths: `/ingest`, `/features`, and `/models`.
- Keep ML backends scalable through Compose v2 `--scale` with Docker DNS re-resolution in Nginx.
- Add `make prod-scale-ml` to scale ML replicas and reload the gateway.
- Export `NGINX_IMAGE` and ML replica defaults in `.env.template`.
- Require `NGINX_IMAGE` in Compose, consistently with the other runtime images.
- Keep runner execution restricted to typed `ingest`, `features`, and `models` jobs.
- Update unit coverage for the `/src/job_runner` concurrency contract.

## Scale-out runtime substrate

The runner now calls only the internal gateway:

```text
job-runner-api -> ml-gateway -> ml-*-prod replicas
```

The gateway configuration uses Docker embedded DNS with a short validity window,
so Compose-scaled service replicas can be discovered without requiring a runner
restart. The Make target still performs an explicit Nginx reload after scaling to
make the live-test path deterministic.

Example live scaling command:

```bash
make prod-scale-ml \
  ML_INGEST_REPLICAS=2 \
  ML_FEATURES_REPLICAS=2 \
  ML_MODELS_REPLICAS=2
```

## Scope notes

Per project testing rules clarified during implementation:

- unit tests remain scoped to code exposed under `/src`;
- integration tests remain scoped to behavior exposed by `/src`;
- Airflow/Compose production-like transverse validation is intentionally left for the next acceptance story.

This story still includes the Compose/Nginx substrate required to demonstrate
bounded local production-like execution during a live production launch test.

## Follow-up architecture note

The current `docker/dev` runtime still differs structurally from `docker/prod`,
not only by volume and host exposure. A follow-up story should evaluate aligning
`docker/dev` with the prod-like service topology by removing Docker socket based
DAG execution, using the same `job-runner-api`/ML service path, and keeping dev
specificity mostly to mounted volumes, host ports, and debug exposure.

## Validation

Not run in this environment.

Recommended local checks:

```bash
pytest tests/unit/job_runner/test_executor.py
pytest tests/integration/test_job_runner_api.py
make prod-compose-config
make prod-scale-ml ML_INGEST_REPLICAS=2 ML_FEATURES_REPLICAS=2 ML_MODELS_REPLICAS=2
```

## Links

Closes #96
